### PR TITLE
feat(P2-01): GitHub PAT storage via OS keychain

### DIFF
--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -43,8 +43,45 @@ pub fn remove_repository(path: String) -> Result<AppConfig, String> {
     Ok(config)
 }
 
-/// Recursively scan a directory for git repositories and return candidate paths.
-/// Does NOT add them to config — the frontend confirms the list first.
+// ─── GitHub PAT (OS keychain) ─────────────────────────────────────────────────
+
+/// Saves the GitHub PAT to the OS keychain using the key from config.
+#[tauri::command]
+pub fn set_github_pat(pat: String) -> Result<(), String> {
+    let config = load_config()?;
+    let entry = keyring::Entry::new(&config.settings.github_keychain_key, "github")
+        .map_err(|e| e.to_string())?;
+    entry.set_password(&pat).map_err(|e| e.to_string())
+}
+
+/// Returns the stored GitHub PAT, or None if not set.
+#[tauri::command]
+pub fn get_github_pat() -> Result<Option<String>, String> {
+    let config = load_config()?;
+    let entry = keyring::Entry::new(&config.settings.github_keychain_key, "github")
+        .map_err(|e| e.to_string())?;
+    match entry.get_password() {
+        Ok(pat) => Ok(Some(pat)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Removes the GitHub PAT from the OS keychain.
+#[tauri::command]
+pub fn delete_github_pat() -> Result<(), String> {
+    let config = load_config()?;
+    let entry = keyring::Entry::new(&config.settings.github_keychain_key, "github")
+        .map_err(|e| e.to_string())?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+// ─── scan_directory ───────────────────────────────────────────────────────────
+
 #[tauri::command]
 pub fn scan_directory(root: String) -> Result<Vec<String>, String> {
     use std::path::Path;

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -45,25 +45,33 @@ pub fn remove_repository(path: String) -> Result<AppConfig, String> {
 
 // ─── GitHub PAT (OS keychain) ─────────────────────────────────────────────────
 
-/// Saves the GitHub PAT to the OS keychain using the key from config.
-#[tauri::command]
-pub fn set_github_pat(pat: String) -> Result<(), String> {
-    let config = load_config()?;
-    let entry = keyring::Entry::new(&config.settings.github_keychain_key, "github")
-        .map_err(|e| e.to_string())?;
-    entry.set_password(&pat).map_err(|e| e.to_string())
+fn keychain_entry(config: &crate::config::AppConfig) -> Result<keyring::Entry, String> {
+    keyring::Entry::new(&config.settings.github_keychain_key, "github")
+        .map_err(|e| format!("OS キーチェーンへのアクセスに失敗しました: {e}"))
 }
 
-/// Returns the stored GitHub PAT, or None if not set.
+/// Trims, validates, and saves the GitHub PAT to the OS keychain.
 #[tauri::command]
-pub fn get_github_pat() -> Result<Option<String>, String> {
+pub fn set_github_pat(pat: String) -> Result<(), String> {
+    let trimmed = pat.trim();
+    if trimmed.is_empty() {
+        return Err("GitHub PAT を入力してください".to_string());
+    }
     let config = load_config()?;
-    let entry = keyring::Entry::new(&config.settings.github_keychain_key, "github")
-        .map_err(|e| e.to_string())?;
-    match entry.get_password() {
-        Ok(pat) => Ok(Some(pat)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(e) => Err(e.to_string()),
+    keychain_entry(&config)?
+        .set_password(trimmed)
+        .map_err(|e| format!("GitHub PAT の保存に失敗しました: {e}"))
+}
+
+/// Returns true if a GitHub PAT is stored, false if not.
+/// The PAT value is never exposed over IPC; retrieval is internal to Rust commands.
+#[tauri::command]
+pub fn has_github_pat() -> Result<bool, String> {
+    let config = load_config()?;
+    match keychain_entry(&config)?.get_password() {
+        Ok(_) => Ok(true),
+        Err(keyring::Error::NoEntry) => Ok(false),
+        Err(e) => Err(format!("OS キーチェーンの読み取りに失敗しました: {e}")),
     }
 }
 
@@ -71,12 +79,10 @@ pub fn get_github_pat() -> Result<Option<String>, String> {
 #[tauri::command]
 pub fn delete_github_pat() -> Result<(), String> {
     let config = load_config()?;
-    let entry = keyring::Entry::new(&config.settings.github_keychain_key, "github")
-        .map_err(|e| e.to_string())?;
-    match entry.delete_credential() {
+    match keychain_entry(&config)?.delete_credential() {
         Ok(()) => Ok(()),
         Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(e.to_string()),
+        Err(e) => Err(format!("GitHub PAT の削除に失敗しました: {e}")),
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ mod models;
 
 use commands::{
     config_cmd::{
-        add_repository, delete_github_pat, get_config, get_github_pat, remove_repository,
+        add_repository, delete_github_pat, get_config, has_github_pat, remove_repository,
         scan_directory, set_github_pat, update_settings,
     },
     dsx::{dsx_check, repo_cleanup, repo_cleanup_preview, repo_update},
@@ -24,7 +24,7 @@ pub fn run() {
             update_settings,
             // GitHub PAT
             set_github_pat,
-            get_github_pat,
+            has_github_pat,
             delete_github_pat,
             // Repo / git2
             list_repositories,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,10 @@ mod config;
 mod models;
 
 use commands::{
-    config_cmd::{add_repository, get_config, remove_repository, scan_directory, update_settings},
+    config_cmd::{
+        add_repository, delete_github_pat, get_config, get_github_pat, remove_repository,
+        scan_directory, set_github_pat, update_settings,
+    },
     dsx::{dsx_check, repo_cleanup, repo_cleanup_preview, repo_update},
     repo::{delete_branches, fetch_all, get_branches, get_repo_status, list_repositories},
 };
@@ -19,6 +22,10 @@ pub fn run() {
             remove_repository,
             scan_directory,
             update_settings,
+            // GitHub PAT
+            set_github_pat,
+            get_github_pat,
+            delete_github_pat,
             // Repo / git2
             list_repositories,
             get_repo_status,

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -53,6 +53,17 @@ export const deleteBranches = (repo_path: string, names: string[]) =>
 export const fetchAll = (repo_path: string) =>
   tauriInvoke<FetchResult>('fetch_all', { repo_path });
 
+// ─── GitHub PAT ──────────────────────────────────────────────────────────────
+
+export const setGithubPat = (pat: string) =>
+  tauriInvoke<void>('set_github_pat', { pat });
+
+export const getGithubPat = () =>
+  tauriInvoke<string | null>('get_github_pat');
+
+export const deleteGithubPat = () =>
+  tauriInvoke<void>('delete_github_pat');
+
 // ─── dsx ─────────────────────────────────────────────────────────────────────
 
 export const dsxCheck = () =>

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -58,8 +58,9 @@ export const fetchAll = (repo_path: string) =>
 export const setGithubPat = (pat: string) =>
   tauriInvoke<void>('set_github_pat', { pat });
 
-export const getGithubPat = () =>
-  tauriInvoke<string | null>('get_github_pat');
+/** Returns true if a PAT is stored. The secret value never crosses the IPC boundary. */
+export const hasGithubPat = () =>
+  tauriInvoke<boolean>('has_github_pat');
 
 export const deleteGithubPat = () =>
   tauriInvoke<void>('delete_github_pat');

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, dsxCheck, getGithubPat, setGithubPat, deleteGithubPat } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus } from '../types';
 
@@ -18,7 +18,7 @@ export default function Settings() {
   useEffect(() => {
     getConfig().then(setConfig).catch((e) => addToast(String(e), 'error'));
     dsxCheck().then(setDsxStatus).catch(() => setDsxStatus({ available: false, version: null, path: null }));
-    getGithubPat().then((p) => setPatStored(p !== null)).catch(() => setPatStored(false));
+    hasGithubPat().then(setPatStored).catch(() => setPatStored(false));
   }, []);
 
   const handleAddRepo = async () => {

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, dsxCheck } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, dsxCheck, getGithubPat, setGithubPat, deleteGithubPat } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus } from '../types';
 
@@ -11,10 +11,14 @@ export default function Settings() {
   const { loadRepos } = useRepoStore();
   const [config, setConfig]       = useState<AppConfig | null>(null);
   const [dsxStatus, setDsxStatus] = useState<DsxStatus | null>(null);
+  const [patStored, setPatStored] = useState<boolean | null>(null);
+  const [patInput, setPatInput]   = useState('');
+  const [patLoading, setPatLoading] = useState(false);
 
   useEffect(() => {
     getConfig().then(setConfig).catch((e) => addToast(String(e), 'error'));
     dsxCheck().then(setDsxStatus).catch(() => setDsxStatus({ available: false, version: null, path: null }));
+    getGithubPat().then((p) => setPatStored(p !== null)).catch(() => setPatStored(false));
   }, []);
 
   const handleAddRepo = async () => {
@@ -29,6 +33,35 @@ export default function Settings() {
       addToast(`Added: ${name}`, 'success');
     } catch (e) {
       addToast(String(e), 'error');
+    }
+  };
+
+  const handleSavePat = async () => {
+    const trimmed = patInput.trim();
+    if (!trimmed) return;
+    setPatLoading(true);
+    try {
+      await setGithubPat(trimmed);
+      setPatStored(true);
+      setPatInput('');
+      addToast('GitHub PAT を保存しました', 'success');
+    } catch (e) {
+      addToast(String(e), 'error');
+    } finally {
+      setPatLoading(false);
+    }
+  };
+
+  const handleClearPat = async () => {
+    setPatLoading(true);
+    try {
+      await deleteGithubPat();
+      setPatStored(false);
+      addToast('GitHub PAT を削除しました', 'success');
+    } catch (e) {
+      addToast(String(e), 'error');
+    } finally {
+      setPatLoading(false);
     }
   };
 
@@ -83,6 +116,49 @@ export default function Settings() {
           ) : (
             <div style={{ fontSize: 12, color: 'var(--text3)' }}>Checking…</div>
           )}
+        </section>
+
+        {/* GitHub PAT */}
+        <section style={{ marginBottom: 32 }}>
+          <SectionTitle>GitHub</SectionTitle>
+          <div style={{ fontSize: 12, color: 'var(--text3)', marginBottom: 10, lineHeight: 1.65 }}>
+            Personal Access Token (PAT) を OS キーチェーンに保存します。
+            PR / Issue 連携は Phase 2 で有効になります。
+          </div>
+          {patStored && (
+            <div style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              marginBottom: 10, fontSize: 12, color: 'var(--green)',
+            }}>
+              <span>✓ PAT が保存されています</span>
+              <AppBtn variant="danger" onClick={handleClearPat} disabled={patLoading}>
+                Clear
+              </AppBtn>
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <input
+              type="password"
+              placeholder={patStored ? '新しい PAT で上書き…' : 'ghp_xxxxxxxxxxxx'}
+              value={patInput}
+              onChange={(e) => setPatInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSavePat()}
+              style={{
+                flex: 1,
+                background: 'var(--bg3)',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--r)',
+                color: 'var(--text1)',
+                fontSize: 12,
+                fontFamily: 'var(--font-mono)',
+                padding: '6px 10px',
+                outline: 'none',
+              }}
+            />
+            <AppBtn variant="primary" onClick={handleSavePat} disabled={patLoading || !patInput.trim()}>
+              Save
+            </AppBtn>
+          </div>
         </section>
 
         {/* Repositories */}

--- a/tasks.md
+++ b/tasks.md
@@ -133,7 +133,7 @@
 
 ## Phase 2 — GitHub 連携 + コミットグラフ + dsx env/sys (weeks 3–4)
 
-- [ ] P2-01: PAT 設定 UI + `keyring` クレートで OS キーチェーンに保存
+- [x] P2-01: PAT 設定 UI + `keyring` クレートで OS キーチェーンに保存
 - [ ] P2-02: `commands/github.rs` — `get_pull_requests` (GitHub REST API GET /repos/{o}/{r}/pulls)
 - [ ] P2-03: `commands/github.rs` — `get_issues` (state: open/closed/all)
 - [ ] P2-04: `commands/github.rs` — `get_check_runs` (CI ステータス取得)


### PR DESCRIPTION
## Summary

- GitHub Personal Access Token を OS キーチェーン（Windows: Credential Manager / macOS: Keychain）に保存・取得・削除する Tauri コマンドを追加
- Settings ビューに GitHub PAT 入力 UI を追加
- Phase 2 の GitHub API タスク（P2-02〜P2-05）の前提となる基盤

## 変更内容

### Rust (`src-tauri/`)
- `commands/config_cmd.rs`: `set_github_pat` / `get_github_pat` / `delete_github_pat` の3コマンドを追加
  - `keyring::Entry::new(github_keychain_key, "github")` でキーチェーンを操作
  - `get_github_pat` は PAT 未設定時に `None` を返す（エラーなし）
- `lib.rs`: 3コマンドを `invoke_handler!` に登録

### Frontend (`src/`)
- `lib/invoke.ts`: `setGithubPat` / `getGithubPat` / `deleteGithubPat` ラッパーを追加
- `views/Settings.tsx`: GitHub セクションを追加
  - パスワード入力 + Save ボタン（Enter キー対応）
  - PAT 保存済み時に「✓ PAT が保存されています」+ Clear ボタンを表示
  - マウント時に `getGithubPat` で現在の保存状態を確認

## Test plan

- [x] CI (GitHub Actions) がグリーンになることを確認
- [x] Settings 画面に GitHub セクションが表示される
- [x] PAT を入力して Save → 「✓ PAT が保存されています」に変わる
- [x] Clear → 入力欄のみの状態に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)