### PR TITLE
ci: parallelize Rust lint and coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,21 @@ jobs:
         with:
           components: clippy
 
-      - name: Cache cargo (lint)
+      - name: Cache cargo registry (shared)
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-lint-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo target (lint)
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/target
+          key: ${{ runner.os }}-cargo-target-lint-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-target-lint-
 
       - name: cargo clippy
         run: cargo clippy -- -D warnings
@@ -56,15 +62,21 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Cache cargo (coverage)
+      - name: Cache cargo registry (shared)
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-cov-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-cov-
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo target (coverage)
+        uses: actions/cache@v4
+        with:
+          path: src-tauri/target
+          key: ${{ runner.os }}-cargo-target-cov-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-target-cov-
 
       - name: cargo test with coverage
         run: cargo llvm-cov --lcov --output-path lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
     branches: [main]
 
 jobs:
-  rust:
-    name: Rust check / clippy / test / coverage
+  # ── Rust: lint ──────────────────────────────────────────────────────────────
+  # Runs in parallel with rust-coverage.
+  # cargo check is omitted: clippy subsumes it.
+  rust-lint:
+    name: Rust clippy
     runs-on: windows-latest
     defaults:
       run:
@@ -19,26 +22,49 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy, llvm-tools-preview
+          components: clippy
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Cache cargo registry
+      - name: Cache cargo (lint)
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             src-tauri/target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
-      - name: cargo check
-        run: cargo check
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-lint-
 
       - name: cargo clippy
         run: cargo clippy -- -D warnings
+
+  # ── Rust: test + coverage ───────────────────────────────────────────────────
+  # Runs in parallel with rust-lint.
+  rust-coverage:
+    name: Rust test + coverage
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Cache cargo (coverage)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-cov-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-cov-
 
       - name: cargo test with coverage
         run: cargo llvm-cov --lcov --output-path lcov.info
@@ -53,6 +79,7 @@ jobs:
           flags: rust
           fail_ci_if_error: false
 
+  # ── Frontend ─────────────────────────────────────────────────────────────────
   frontend:
     name: Frontend typecheck / build / test / coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `rust` ジョブを `rust-lint` と `rust-coverage` に分割して並列実行
- 冗長な `cargo check` ステップを削除
- 各ジョブに独立したキャッシュキーを設定

## 変更の詳細

### Before（逐次実行）
```
rust job
  └─ cargo check        ← 冗長（clippy が包含）
  └─ cargo clippy       ┐
  └─ cargo llvm-cov     ┘ 依存関係なし → 逐次は無駄
```

### After（並列実行）
```
rust-lint       rust-coverage       frontend
  └─ clippy       └─ llvm-cov         └─ typecheck
                  └─ upload           └─ build
                                      └─ test:coverage
                                      └─ upload
```

### キャッシュ分離
| ジョブ | キャッシュキー | 内容 |
|--------|--------------|------|
| `rust-lint` | `{os}-cargo-lint-{Cargo.lock hash}` | registry + git + target (debug artifacts) |
| `rust-coverage` | `{os}-cargo-cov-{Cargo.lock hash}` | registry + git + target (instrumented artifacts) |

`target/debug/` と `target/llvm-cov-target/` は別ディレクトリだが、キャッシュキーを分けることで並列ジョブ間の書き込み競合を完全に排除する。

### 期待される効果
壁時計時間は `clippy + llvm-cov` の逐次から `max(clippy, llvm-cov)` の並列になる。`cargo check` 削除（~30秒）と合わせ、Rust CI 全体で 1〜2 分の短縮を見込む。

## Test plan

- [x] CI (GitHub Actions) で `rust-lint` / `rust-coverage` / `frontend` が3並列で起動することを確認
- [x] 全ジョブがグリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)