### PR TITLE
feat(P2-02~04): GitHub REST API commands — PRs, Issues, Check Runs

### DIFF
--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -47,7 +47,7 @@ pub fn remove_repository(path: String) -> Result<AppConfig, String> {
 
 /// Internal helper used by GitHub API commands to retrieve the stored PAT.
 /// Not a Tauri command — the secret stays inside the Rust process.
-pub fn load_github_pat() -> Result<String, String> {
+pub(crate) fn load_github_pat() -> Result<String, String> {
     let config = load_config()?;
     match keychain_entry(&config)?.get_password() {
         Ok(pat) => Ok(pat),

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -45,6 +45,19 @@ pub fn remove_repository(path: String) -> Result<AppConfig, String> {
 
 // ─── GitHub PAT (OS keychain) ─────────────────────────────────────────────────
 
+/// Internal helper used by GitHub API commands to retrieve the stored PAT.
+/// Not a Tauri command — the secret stays inside the Rust process.
+pub fn load_github_pat() -> Result<String, String> {
+    let config = load_config()?;
+    match keychain_entry(&config)?.get_password() {
+        Ok(pat) => Ok(pat),
+        Err(keyring::Error::NoEntry) => Err(
+            "GitHub PAT が設定されていません。Settings から PAT を登録してください。".to_string(),
+        ),
+        Err(e) => Err(format!("OS キーチェーンの読み取りに失敗しました: {e}")),
+    }
+}
+
 fn keychain_entry(config: &crate::config::AppConfig) -> Result<keyring::Entry, String> {
     keyring::Entry::new(&config.settings.github_keychain_key, "github")
         .map_err(|e| format!("OS キーチェーンへのアクセスに失敗しました: {e}"))

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1,19 +1,94 @@
 use crate::commands::config_cmd::load_github_pat;
 use crate::models::{CheckRun, Issue, PullRequest};
+use reqwest::{StatusCode, Url};
 use serde::Deserialize;
+use std::sync::OnceLock;
 
 const GITHUB_API: &str = "https://api.github.com";
 const API_VERSION: &str = "2022-11-28";
 
-// ─── HTTP helper ─────────────────────────────────────────────────────────────
+// ─── Shared HTTP client ───────────────────────────────────────────────────────
 
-async fn get<T: for<'de> Deserialize<'de>>(url: &str, pat: &str) -> Result<T, String> {
-    let client = reqwest::Client::builder()
-        .user_agent(concat!("Arbor/", env!("CARGO_PKG_VERSION")))
-        .build()
-        .map_err(|e| format!("HTTP クライアントの初期化に失敗しました: {e}"))?;
+static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
-    let resp = client
+fn get_client() -> &'static reqwest::Client {
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .user_agent(concat!("Arbor/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .expect("HTTP client build should never fail")
+    })
+}
+
+// ─── URL builder ─────────────────────────────────────────────────────────────
+
+/// Builds a GitHub API URL with properly percent-encoded path segments.
+fn api_url(path_parts: &[&str], params: &[(&str, &str)]) -> Result<Url, String> {
+    let mut url = Url::parse(GITHUB_API).map_err(|e| e.to_string())?;
+    url.path_segments_mut()
+        .map_err(|_| "URL path build error".to_string())?
+        .extend(path_parts);
+    if !params.is_empty() {
+        url.query_pairs_mut().extend_pairs(params.iter().copied());
+    }
+    Ok(url)
+}
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+fn check_status(status: StatusCode) -> Result<(), String> {
+    if status == StatusCode::UNAUTHORIZED {
+        return Err(
+            "GitHub PAT が無効です。Settings から PAT を更新してください。".to_string(),
+        );
+    }
+    if status == StatusCode::NOT_FOUND {
+        return Err(
+            "リポジトリが見つかりません。owner / repo 名を確認してください。".to_string(),
+        );
+    }
+    if !status.is_success() {
+        return Err(format!("GitHub API エラー: HTTP {status}"));
+    }
+    Ok(())
+}
+
+/// Fetches all pages from an endpoint that returns a JSON array.
+/// Follows `Link: rel="next"` headers until exhausted.
+async fn get_all_pages<T: for<'de> Deserialize<'de>>(
+    first_url: Url,
+    pat: &str,
+) -> Result<Vec<T>, String> {
+    let mut results: Vec<T> = Vec::new();
+    let mut next: Option<String> = Some(first_url.to_string());
+
+    while let Some(url) = next {
+        let resp = get_client()
+            .get(&url)
+            .header("Authorization", format!("Bearer {pat}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", API_VERSION)
+            .send()
+            .await
+            .map_err(|e| format!("GitHub API リクエストに失敗しました: {e}"))?;
+
+        check_status(resp.status())?;
+
+        next = parse_next_link(resp.headers());
+
+        let mut page: Vec<T> = resp
+            .json()
+            .await
+            .map_err(|e| format!("GitHub API レスポンスのパースに失敗しました: {e}"))?;
+        results.append(&mut page);
+    }
+
+    Ok(results)
+}
+
+/// Fetches a single response (non-array wrapper objects like CheckRunsResponse).
+async fn get_once<T: for<'de> Deserialize<'de>>(url: Url, pat: &str) -> Result<T, String> {
+    let resp = get_client()
         .get(url)
         .header("Authorization", format!("Bearer {pat}"))
         .header("Accept", "application/vnd.github+json")
@@ -22,24 +97,27 @@ async fn get<T: for<'de> Deserialize<'de>>(url: &str, pat: &str) -> Result<T, St
         .await
         .map_err(|e| format!("GitHub API リクエストに失敗しました: {e}"))?;
 
-    let status = resp.status();
-    if status == 401 {
-        return Err(
-            "GitHub PAT が無効です。Settings から PAT を更新してください。".to_string(),
-        );
-    }
-    if status == 404 {
-        return Err(
-            "リポジトリが見つかりません。owner / repo 名を確認してください。".to_string(),
-        );
-    }
-    if !status.is_success() {
-        return Err(format!("GitHub API エラー: HTTP {status}"));
-    }
+    check_status(resp.status())?;
 
     resp.json::<T>()
         .await
         .map_err(|e| format!("GitHub API レスポンスのパースに失敗しました: {e}"))
+}
+
+/// Parses the URL of the next page from a `Link` response header.
+fn parse_next_link(headers: &reqwest::header::HeaderMap) -> Option<String> {
+    let link = headers.get("link")?.to_str().ok()?;
+    // Format: <https://...?page=2>; rel="next", <...>; rel="last"
+    for part in link.split(',') {
+        let part = part.trim();
+        if part.contains(r#"rel="next""#) {
+            if let Some(url_part) = part.split(';').next() {
+                let url = url_part.trim().trim_start_matches('<').trim_end_matches('>');
+                return Some(url.to_string());
+            }
+        }
+    }
+    None
 }
 
 // ─── get_pull_requests (P2-02) ────────────────────────────────────────────────
@@ -70,7 +148,7 @@ struct RawRef {
     ref_name: String,
 }
 
-/// Returns pull requests for the given repository.
+/// Returns pull requests for the given repository (all pages).
 /// `state`: "open" | "closed" | "all"  (defaults to "open")
 #[tauri::command]
 pub async fn get_pull_requests(
@@ -80,10 +158,11 @@ pub async fn get_pull_requests(
 ) -> Result<Vec<PullRequest>, String> {
     let pat = load_github_pat()?;
     let state = state.as_deref().unwrap_or("open");
-    let url = format!(
-        "{GITHUB_API}/repos/{owner}/{repo}/pulls?state={state}&per_page=100"
-    );
-    let raw: Vec<RawPullRequest> = get(&url, &pat).await?;
+    let url = api_url(
+        &["repos", &owner, &repo, "pulls"],
+        &[("state", state), ("per_page", "100")],
+    )?;
+    let raw: Vec<RawPullRequest> = get_all_pages(url, &pat).await?;
     Ok(raw
         .into_iter()
         .map(|r| PullRequest {
@@ -124,7 +203,7 @@ struct RawLabel {
     name: String,
 }
 
-/// Returns issues for the given repository (pull requests are excluded).
+/// Returns issues for the given repository (all pages; pull requests are excluded).
 /// `state`: "open" | "closed" | "all"  (defaults to "open")
 #[tauri::command]
 pub async fn get_issues(
@@ -134,10 +213,11 @@ pub async fn get_issues(
 ) -> Result<Vec<Issue>, String> {
     let pat = load_github_pat()?;
     let state = state.as_deref().unwrap_or("open");
-    let url = format!(
-        "{GITHUB_API}/repos/{owner}/{repo}/issues?state={state}&per_page=100"
-    );
-    let raw: Vec<RawIssue> = get(&url, &pat).await?;
+    let url = api_url(
+        &["repos", &owner, &repo, "issues"],
+        &[("state", state), ("per_page", "100")],
+    )?;
+    let raw: Vec<RawIssue> = get_all_pages(url, &pat).await?;
     Ok(raw
         .into_iter()
         .filter(|r| r.pull_request.is_none())
@@ -174,6 +254,7 @@ struct RawCheckRun {
 }
 
 /// Returns check runs for the given commit ref (branch name or SHA).
+/// Branch names containing `/` are correctly percent-encoded in the URL path.
 #[tauri::command]
 pub async fn get_check_runs(
     owner: String,
@@ -181,10 +262,11 @@ pub async fn get_check_runs(
     git_ref: String,
 ) -> Result<Vec<CheckRun>, String> {
     let pat = load_github_pat()?;
-    let url = format!(
-        "{GITHUB_API}/repos/{owner}/{repo}/commits/{git_ref}/check-runs?per_page=100"
-    );
-    let raw: CheckRunsResponse = get(&url, &pat).await?;
+    let url = api_url(
+        &["repos", &owner, &repo, "commits", &git_ref, "check-runs"],
+        &[("per_page", "100")],
+    )?;
+    let raw: CheckRunsResponse = get_once(url, &pat).await?;
     Ok(raw
         .check_runs
         .into_iter()

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -105,7 +105,7 @@ async fn get_once<T: for<'de> Deserialize<'de>>(url: Url, pat: &str) -> Result<T
 }
 
 /// Parses the URL of the next page from a `Link` response header.
-fn parse_next_link(headers: &reqwest::header::HeaderMap) -> Option<String> {
+pub(crate) fn parse_next_link(headers: &reqwest::header::HeaderMap) -> Option<String> {
     let link = headers.get("link")?.to_str().ok()?;
     // Format: <https://...?page=2>; rel="next", <...>; rel="last"
     for part in link.split(',') {
@@ -280,4 +280,124 @@ pub async fn get_check_runs(
             completed_at: r.completed_at,
         })
         .collect())
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::{HeaderMap, HeaderValue, LINK};
+
+    // ── api_url ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn api_url_simple_path() {
+        let url = api_url(&["repos", "owner", "repo", "pulls"], &[("state", "open")])
+            .expect("should build");
+        assert_eq!(
+            url.as_str(),
+            "https://api.github.com/repos/owner/repo/pulls?state=open"
+        );
+    }
+
+    #[test]
+    fn api_url_encodes_slash_in_git_ref() {
+        // Branch names like "feature/foo" must be percent-encoded as path segments.
+        let url = api_url(
+            &["repos", "owner", "repo", "commits", "feature/foo", "check-runs"],
+            &[("per_page", "100")],
+        )
+        .expect("should build");
+        assert!(
+            url.as_str().contains("feature%2Ffoo"),
+            "slash in branch name should be encoded: {url}"
+        );
+    }
+
+    #[test]
+    fn api_url_no_query_params() {
+        let url = api_url(&["repos", "owner", "repo", "pulls"], &[]).expect("should build");
+        assert_eq!(url.as_str(), "https://api.github.com/repos/owner/repo/pulls");
+    }
+
+    #[test]
+    fn api_url_multiple_params() {
+        let url = api_url(
+            &["repos", "o", "r", "issues"],
+            &[("state", "all"), ("per_page", "100")],
+        )
+        .expect("should build");
+        let s = url.as_str();
+        assert!(s.contains("state=all"), "{s}");
+        assert!(s.contains("per_page=100"), "{s}");
+    }
+
+    // ── check_status ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn check_status_ok() {
+        assert!(check_status(StatusCode::OK).is_ok());
+        assert!(check_status(StatusCode::CREATED).is_ok());
+    }
+
+    #[test]
+    fn check_status_unauthorized() {
+        let err = check_status(StatusCode::UNAUTHORIZED).unwrap_err();
+        assert!(err.contains("PAT"), "expected PAT mention: {err}");
+    }
+
+    #[test]
+    fn check_status_not_found() {
+        let err = check_status(StatusCode::NOT_FOUND).unwrap_err();
+        assert!(err.contains("リポジトリ"), "expected repo mention: {err}");
+    }
+
+    #[test]
+    fn check_status_other_error() {
+        let err = check_status(StatusCode::INTERNAL_SERVER_ERROR).unwrap_err();
+        assert!(err.contains("500"), "expected HTTP status code: {err}");
+    }
+
+    // ── parse_next_link ───────────────────────────────────────────────────────
+
+    fn make_link_header(value: &str) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        map.insert(LINK, HeaderValue::from_str(value).unwrap());
+        map
+    }
+
+    #[test]
+    fn parse_next_link_returns_next_url() {
+        let headers = make_link_header(
+            r#"<https://api.github.com/repos/o/r/pulls?page=2>; rel="next", <https://api.github.com/repos/o/r/pulls?page=5>; rel="last""#,
+        );
+        let next = parse_next_link(&headers);
+        assert_eq!(
+            next.as_deref(),
+            Some("https://api.github.com/repos/o/r/pulls?page=2")
+        );
+    }
+
+    #[test]
+    fn parse_next_link_no_next_returns_none() {
+        let headers = make_link_header(
+            r#"<https://api.github.com/repos/o/r/pulls?page=1>; rel="prev""#,
+        );
+        assert!(parse_next_link(&headers).is_none());
+    }
+
+    #[test]
+    fn parse_next_link_absent_header_returns_none() {
+        assert!(parse_next_link(&HeaderMap::new()).is_none());
+    }
+
+    #[test]
+    fn parse_next_link_last_page_only() {
+        // Only "last" present (single-page response has no "next").
+        let headers = make_link_header(
+            r#"<https://api.github.com/repos/o/r/pulls?page=1>; rel="last""#,
+        );
+        assert!(parse_next_link(&headers).is_none());
+    }
 }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -1,0 +1,201 @@
+use crate::commands::config_cmd::load_github_pat;
+use crate::models::{CheckRun, Issue, PullRequest};
+use serde::Deserialize;
+
+const GITHUB_API: &str = "https://api.github.com";
+const API_VERSION: &str = "2022-11-28";
+
+// ─── HTTP helper ─────────────────────────────────────────────────────────────
+
+async fn get<T: for<'de> Deserialize<'de>>(url: &str, pat: &str) -> Result<T, String> {
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("Arbor/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| format!("HTTP クライアントの初期化に失敗しました: {e}"))?;
+
+    let resp = client
+        .get(url)
+        .header("Authorization", format!("Bearer {pat}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", API_VERSION)
+        .send()
+        .await
+        .map_err(|e| format!("GitHub API リクエストに失敗しました: {e}"))?;
+
+    let status = resp.status();
+    if status == 401 {
+        return Err(
+            "GitHub PAT が無効です。Settings から PAT を更新してください。".to_string(),
+        );
+    }
+    if status == 404 {
+        return Err(
+            "リポジトリが見つかりません。owner / repo 名を確認してください。".to_string(),
+        );
+    }
+    if !status.is_success() {
+        return Err(format!("GitHub API エラー: HTTP {status}"));
+    }
+
+    resp.json::<T>()
+        .await
+        .map_err(|e| format!("GitHub API レスポンスのパースに失敗しました: {e}"))
+}
+
+// ─── get_pull_requests (P2-02) ────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct RawPullRequest {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    user: RawUser,
+    created_at: String,
+    updated_at: String,
+    draft: bool,
+    merged_at: Option<String>,
+    head: RawRef,
+    base: RawRef,
+}
+
+#[derive(Deserialize)]
+struct RawUser {
+    login: String,
+}
+
+#[derive(Deserialize)]
+struct RawRef {
+    #[serde(rename = "ref")]
+    ref_name: String,
+}
+
+/// Returns pull requests for the given repository.
+/// `state`: "open" | "closed" | "all"  (defaults to "open")
+#[tauri::command]
+pub async fn get_pull_requests(
+    owner: String,
+    repo: String,
+    state: Option<String>,
+) -> Result<Vec<PullRequest>, String> {
+    let pat = load_github_pat()?;
+    let state = state.as_deref().unwrap_or("open");
+    let url = format!(
+        "{GITHUB_API}/repos/{owner}/{repo}/pulls?state={state}&per_page=100"
+    );
+    let raw: Vec<RawPullRequest> = get(&url, &pat).await?;
+    Ok(raw
+        .into_iter()
+        .map(|r| PullRequest {
+            number: r.number,
+            title: r.title,
+            state: r.state,
+            html_url: r.html_url,
+            user_login: r.user.login,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            draft: r.draft,
+            merged_at: r.merged_at,
+            head_ref: r.head.ref_name,
+            base_ref: r.base.ref_name,
+        })
+        .collect())
+}
+
+// ─── get_issues (P2-03) ──────────────────────────────────────────────────────
+
+/// The `/issues` endpoint also returns PRs; filter them out via `pull_request`.
+#[derive(Deserialize)]
+struct RawIssue {
+    number: u64,
+    title: String,
+    state: String,
+    html_url: String,
+    user: RawUser,
+    created_at: String,
+    updated_at: String,
+    body: Option<String>,
+    labels: Vec<RawLabel>,
+    pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct RawLabel {
+    name: String,
+}
+
+/// Returns issues for the given repository (pull requests are excluded).
+/// `state`: "open" | "closed" | "all"  (defaults to "open")
+#[tauri::command]
+pub async fn get_issues(
+    owner: String,
+    repo: String,
+    state: Option<String>,
+) -> Result<Vec<Issue>, String> {
+    let pat = load_github_pat()?;
+    let state = state.as_deref().unwrap_or("open");
+    let url = format!(
+        "{GITHUB_API}/repos/{owner}/{repo}/issues?state={state}&per_page=100"
+    );
+    let raw: Vec<RawIssue> = get(&url, &pat).await?;
+    Ok(raw
+        .into_iter()
+        .filter(|r| r.pull_request.is_none())
+        .map(|r| Issue {
+            number: r.number,
+            title: r.title,
+            state: r.state,
+            html_url: r.html_url,
+            user_login: r.user.login,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            body: r.body,
+            labels: r.labels.into_iter().map(|l| l.name).collect(),
+        })
+        .collect())
+}
+
+// ─── get_check_runs (P2-04) ──────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct CheckRunsResponse {
+    check_runs: Vec<RawCheckRun>,
+}
+
+#[derive(Deserialize)]
+struct RawCheckRun {
+    id: u64,
+    name: String,
+    status: String,
+    conclusion: Option<String>,
+    html_url: String,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+}
+
+/// Returns check runs for the given commit ref (branch name or SHA).
+#[tauri::command]
+pub async fn get_check_runs(
+    owner: String,
+    repo: String,
+    git_ref: String,
+) -> Result<Vec<CheckRun>, String> {
+    let pat = load_github_pat()?;
+    let url = format!(
+        "{GITHUB_API}/repos/{owner}/{repo}/commits/{git_ref}/check-runs?per_page=100"
+    );
+    let raw: CheckRunsResponse = get(&url, &pat).await?;
+    Ok(raw
+        .check_runs
+        .into_iter()
+        .map(|r| CheckRun {
+            id: r.id,
+            name: r.name,
+            status: r.status,
+            conclusion: r.conclusion,
+            html_url: r.html_url,
+            started_at: r.started_at,
+            completed_at: r.completed_at,
+        })
+        .collect())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod config_cmd;
 pub mod dsx;
+pub mod github;
 pub mod repo;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use commands::{
         scan_directory, set_github_pat, update_settings,
     },
     dsx::{dsx_check, repo_cleanup, repo_cleanup_preview, repo_update},
+    github::{get_check_runs, get_issues, get_pull_requests},
     repo::{delete_branches, fetch_all, get_branches, get_repo_status, list_repositories},
 };
 
@@ -26,6 +27,10 @@ pub fn run() {
             set_github_pat,
             has_github_pat,
             delete_github_pat,
+            // GitHub API
+            get_pull_requests,
+            get_issues,
+            get_check_runs,
             // Repo / git2
             list_repositories,
             get_repo_status,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -79,3 +79,53 @@ pub struct DsxOutput {
 pub struct FetchResult {
     pub updated_refs: Vec<String>,
 }
+
+// ─── GitHub API response types ────────────────────────────────────────────────
+
+/// A GitHub pull request (subset of fields returned by the REST API).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PullRequest {
+    pub number: u64,
+    pub title: String,
+    /// "open" | "closed"
+    pub state: String,
+    pub html_url: String,
+    pub user_login: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub draft: bool,
+    pub merged_at: Option<String>,
+    /// Source branch name.
+    pub head_ref: String,
+    /// Target branch name.
+    pub base_ref: String,
+}
+
+/// A GitHub issue (PR items are excluded).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Issue {
+    pub number: u64,
+    pub title: String,
+    /// "open" | "closed"
+    pub state: String,
+    pub html_url: String,
+    pub user_login: String,
+    pub created_at: String,
+    pub updated_at: String,
+    pub body: Option<String>,
+    pub labels: Vec<String>,
+}
+
+/// A single check run result for a commit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckRun {
+    pub id: u64,
+    pub name: String,
+    /// "queued" | "in_progress" | "completed"
+    pub status: String,
+    /// "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required"
+    pub conclusion: Option<String>,
+    pub html_url: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -6,10 +6,13 @@ import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import type {
   AppConfig,
   BranchInfo,
+  CheckRun,
   DeleteResult,
   DsxOutput,
   DsxStatus,
   FetchResult,
+  Issue,
+  PullRequest,
   RepoInfo,
 } from '../types';
 
@@ -64,6 +67,20 @@ export const hasGithubPat = () =>
 
 export const deleteGithubPat = () =>
   tauriInvoke<void>('delete_github_pat');
+
+// ─── GitHub API ──────────────────────────────────────────────────────────────
+
+/** `state`: "open" | "closed" | "all" (default: "open") */
+export const getPullRequests = (owner: string, repo: string, state?: string) =>
+  tauriInvoke<PullRequest[]>('get_pull_requests', { owner, repo, state });
+
+/** `state`: "open" | "closed" | "all" (default: "open"). PRs are excluded. */
+export const getIssues = (owner: string, repo: string, state?: string) =>
+  tauriInvoke<Issue[]>('get_issues', { owner, repo, state });
+
+/** Returns check runs for the given branch name or commit SHA. */
+export const getCheckRuns = (owner: string, repo: string, git_ref: string) =>
+  tauriInvoke<CheckRun[]>('get_check_runs', { owner, repo, git_ref });
 
 // ─── dsx ─────────────────────────────────────────────────────────────────────
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,6 +89,50 @@ export interface RepoConfig {
   github_repo: string | null;
 }
 
+// ─── Mirror of GitHub API response types in models.rs ───────────────────────
+
+export interface PullRequest {
+  number: number;
+  title: string;
+  /** "open" | "closed" */
+  state: string;
+  html_url: string;
+  user_login: string;
+  created_at: string;
+  updated_at: string;
+  draft: boolean;
+  merged_at: string | null;
+  /** Source branch name */
+  head_ref: string;
+  /** Target branch name */
+  base_ref: string;
+}
+
+export interface Issue {
+  number: number;
+  title: string;
+  /** "open" | "closed" */
+  state: string;
+  html_url: string;
+  user_login: string;
+  created_at: string;
+  updated_at: string;
+  body: string | null;
+  labels: string[];
+}
+
+export interface CheckRun {
+  id: number;
+  name: string;
+  /** "queued" | "in_progress" | "completed" */
+  status: string;
+  /** "success" | "failure" | "neutral" | "cancelled" | "skipped" | "timed_out" | "action_required" */
+  conclusion: string | null;
+  html_url: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
 // ─── UI-only types ───────────────────────────────────────────────────────────
 
 export type ViewId = 'overview' | 'branches' | 'graph' | 'prs' | 'cleanup' | 'settings';

--- a/tasks.md
+++ b/tasks.md
@@ -134,9 +134,9 @@
 ## Phase 2 — GitHub 連携 + コミットグラフ + dsx env/sys (weeks 3–4)
 
 - [x] P2-01: PAT 設定 UI + `keyring` クレートで OS キーチェーンに保存
-- [ ] P2-02: `commands/github.rs` — `get_pull_requests` (GitHub REST API GET /repos/{o}/{r}/pulls)
-- [ ] P2-03: `commands/github.rs` — `get_issues` (state: open/closed/all)
-- [ ] P2-04: `commands/github.rs` — `get_check_runs` (CI ステータス取得)
+- [x] P2-02: `commands/github.rs` — `get_pull_requests` (GitHub REST API GET /repos/{o}/{r}/pulls)
+- [x] P2-03: `commands/github.rs` — `get_issues` (state: open/closed/all)
+- [x] P2-04: `commands/github.rs` — `get_check_runs` (CI ステータス取得)
 - [ ] P2-05: `src/views/PullRequests.tsx` — PR / Issue 一覧 + CI ステータスドット
 - [ ] P2-06: TanStack Query 導入 — GitHub API キャッシュ + 5分間隔自動リフレッシュ
 - [ ] P2-07: `commands/repo.rs` — `get_commit_graph` (d3 向け CommitNode 配列 + lane 計算)


### PR DESCRIPTION
## Summary

P2-05（PR/Issue ビュー）と P2-06（TanStack Query）の前提となる GitHub API バックエンドを実装。

## 変更内容

### Rust

| ファイル | 変更 |
|---------|------|
| `models.rs` | `PullRequest` / `Issue` / `CheckRun` 型を追加 |
| `commands/github.rs` | 新規作成。3コマンドを実装 |
| `commands/config_cmd.rs` | `load_github_pat()` 内部ヘルパーを追加（IPC 非公開） |
| `lib.rs` | 3コマンドを `invoke_handler!` に登録 |

**設計上のポイント:**
- PAT は `load_github_pat()` で Rust 内部のみで取得し、IPC 境界を越えない
- 401 → PAT 無効メッセージ、404 → リポジトリ未発見メッセージ を日本語で返す
- `get_issues` は `/issues` エンドポイントが返す PR を `pull_request` フィールドで除外
- `get_check_runs` は branch 名または commit SHA を `git_ref` として受け取る

### Frontend

| ファイル | 変更 |
|---------|------|
| `types/index.ts` | `PullRequest` / `Issue` / `CheckRun` 型を追加 |
| `lib/invoke.ts` | `getPullRequests` / `getIssues` / `getCheckRuns` ラッパーを追加 |

## Test plan

- [ ] CI がグリーンになることを確認
- [ ] PAT 未設定時に適切なエラーメッセージが返ること（P2-12 で UI 対応予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)