### PR TITLE
feat(p2-05/06/12): PullRequests view + TanStack Query

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ToastContainer from './components/Toast';
 import ErrorBoundary from './components/ErrorBoundary';
 import Overview from './views/Overview';
 import Branches from './views/Branches';
+import PullRequests from './views/PullRequests';
 import Cleanup from './views/Cleanup';
 import Settings from './views/Settings';
 import { useRepoStore } from './stores/repoStore';
@@ -64,7 +65,9 @@ export default function App() {
           <ErrorBoundary key="branches" viewName="Branches"><Branches /></ErrorBoundary>
         )}
         {activeView === 'graph'   && <PlaceholderView label="Commit Graph" note="Implemented in Phase 2" />}
-        {activeView === 'prs'     && <PlaceholderView label="PR / Issues"  note="Implemented in Phase 2" />}
+        {activeView === 'prs'     && (
+          <ErrorBoundary key="prs" viewName="PR / Issues"><PullRequests /></ErrorBoundary>
+        )}
         {activeView === 'cleanup' && (
           <ErrorBoundary key="cleanup" viewName="Cleanup"><Cleanup /></ErrorBoundary>
         )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,22 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './styles/global.css';
 import App from './App';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+});
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </StrictMode>,
 );

--- a/src/views/PullRequests.tsx
+++ b/src/views/PullRequests.tsx
@@ -15,7 +15,7 @@ export default function PullRequests() {
   const { navigate } = useUiStore();
   const [tab, setTab] = useState<Tab>('prs');
 
-  const { data: hasPat, isLoading: patLoading } = useQuery({
+  const { data: hasPat, isLoading: patLoading, isError: patError } = useQuery({
     queryKey: ['has_pat'],
     queryFn: hasGithubPat,
     staleTime: 60_000,
@@ -41,21 +41,22 @@ export default function PullRequests() {
     refetchInterval: STALE_MS,
   });
 
-  // CI status for each open PR — one query per unique head_ref
+  // CI status for each open PR — keyed by PR number to avoid cache collisions
+  // (e.g. forks with identically-named branches). head_ref is used as the API ref.
   const checkResults = useQueries({
     queries: prs.map((pr) => ({
-      queryKey: ['checks', owner, repo, pr.head_ref],
+      queryKey: ['checks', owner, repo, pr.number],
       queryFn: () => getCheckRuns(owner!, repo!, pr.head_ref),
-      enabled: apiEnabled,
+      enabled: apiEnabled && tab === 'prs',
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
     })),
   });
 
-  const checkMap = new Map<string, CiStatus>();
+  const checkMap = new Map<number, CiStatus>();
   prs.forEach((pr, i) => {
     const runs: CheckRun[] = checkResults[i]?.data ?? [];
-    checkMap.set(pr.head_ref, deriveCheckStatus(runs));
+    checkMap.set(pr.number, deriveCheckStatus(runs));
   });
 
   // ─── Guards ────────────────────────────────────────────────────────────────
@@ -66,6 +67,16 @@ export default function PullRequests() {
 
   if (patLoading) {
     return <LoadingCard />;
+  }
+
+  if (patError) {
+    return (
+      <EmptyCard
+        message="OS キーチェーンの読み取りに失敗しました"
+        action="Settings を確認する"
+        onAction={() => navigate('settings')}
+      />
+    );
   }
 
   if (!hasPat) {
@@ -152,6 +163,7 @@ function EmptyCard({
       <div style={{ color: 'var(--text2)', fontSize: 14 }}>{message}</div>
       {action && onAction && (
         <button
+          type="button"
           onClick={onAction}
           style={{
             padding: '6px 16px', borderRadius: 'var(--r)',
@@ -181,7 +193,7 @@ function PrTable({
   checkMap,
 }: {
   prs: PullRequest[];
-  checkMap: Map<string, CiStatus>;
+  checkMap: Map<number, CiStatus>;
 }) {
   if (prs.length === 0) {
     return (
@@ -214,7 +226,7 @@ function PrTable({
           <PrRow
             key={pr.number}
             pr={pr}
-            ciStatus={checkMap.get(pr.head_ref) ?? null}
+            ciStatus={checkMap.get(pr.number) ?? null}
           />
         ))}
       </tbody>

--- a/src/views/PullRequests.tsx
+++ b/src/views/PullRequests.tsx
@@ -1,0 +1,387 @@
+import { useState } from 'react';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import AppBar, { AppBtn } from '../components/AppBar';
+import { getPullRequests, getIssues, getCheckRuns, hasGithubPat } from '../lib/invoke';
+import type { CheckRun, Issue, PullRequest } from '../types';
+
+const STALE_MS = 5 * 60 * 1000;
+
+type Tab = 'prs' | 'issues';
+
+export default function PullRequests() {
+  const { selectedRepo } = useRepoStore();
+  const { navigate } = useUiStore();
+  const [tab, setTab] = useState<Tab>('prs');
+
+  const { data: hasPat, isLoading: patLoading } = useQuery({
+    queryKey: ['has_pat'],
+    queryFn: hasGithubPat,
+    staleTime: 60_000,
+  });
+
+  const owner = selectedRepo?.github_owner ?? null;
+  const repo = selectedRepo?.github_repo ?? null;
+  const apiEnabled = !!hasPat && !!owner && !!repo;
+
+  const { data: prs = [], isLoading: prsLoading, error: prsError } = useQuery({
+    queryKey: ['prs', owner, repo],
+    queryFn: () => getPullRequests(owner!, repo!),
+    enabled: apiEnabled,
+    staleTime: STALE_MS,
+    refetchInterval: STALE_MS,
+  });
+
+  const { data: issues = [], isLoading: issuesLoading, error: issuesError } = useQuery({
+    queryKey: ['issues', owner, repo],
+    queryFn: () => getIssues(owner!, repo!),
+    enabled: apiEnabled && tab === 'issues',
+    staleTime: STALE_MS,
+    refetchInterval: STALE_MS,
+  });
+
+  // CI status for each open PR — one query per unique head_ref
+  const checkResults = useQueries({
+    queries: prs.map((pr) => ({
+      queryKey: ['checks', owner, repo, pr.head_ref],
+      queryFn: () => getCheckRuns(owner!, repo!, pr.head_ref),
+      enabled: apiEnabled,
+      staleTime: STALE_MS,
+      refetchInterval: STALE_MS,
+    })),
+  });
+
+  const checkMap = new Map<string, CiStatus>();
+  prs.forEach((pr, i) => {
+    const runs: CheckRun[] = checkResults[i]?.data ?? [];
+    checkMap.set(pr.head_ref, deriveCheckStatus(runs));
+  });
+
+  // ─── Guards ────────────────────────────────────────────────────────────────
+
+  if (!selectedRepo) {
+    return <EmptyCard message="リポジトリを選択してください" />;
+  }
+
+  if (patLoading) {
+    return <LoadingCard />;
+  }
+
+  if (!hasPat) {
+    return (
+      <EmptyCard
+        message="GitHub PAT が設定されていません"
+        action="Settings で設定する"
+        onAction={() => navigate('settings')}
+      />
+    );
+  }
+
+  if (!owner || !repo) {
+    return (
+      <EmptyCard
+        message="このリポジトリに GitHub Owner / Repo が設定されていません"
+        action="Settings で設定する"
+        onAction={() => navigate('settings')}
+      />
+    );
+  }
+
+  const loading = tab === 'prs' ? prsLoading : issuesLoading;
+  const error = tab === 'prs' ? prsError : issuesError;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <AppBar
+        path={
+          <><span style={{ color: 'var(--text2)' }}>{owner}/{repo}</span></>
+        }
+        actions={
+          <>
+            <AppBtn
+              variant={tab === 'prs' ? 'primary' : 'default'}
+              onClick={() => setTab('prs')}
+            >
+              {prs.length > 0 ? `PRs (${prs.length})` : 'PRs'}
+            </AppBtn>
+            <AppBtn
+              variant={tab === 'issues' ? 'primary' : 'default'}
+              onClick={() => setTab('issues')}
+            >
+              Issues
+            </AppBtn>
+          </>
+        }
+      />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 16px 16px' }}>
+        {loading && (
+          <div style={{ padding: 24, color: 'var(--text3)', fontSize: 12 }}>読み込み中…</div>
+        )}
+        {!loading && error && (
+          <div style={{ padding: 24, color: 'var(--red)', fontSize: 12 }}>{String(error)}</div>
+        )}
+        {!loading && !error && tab === 'prs' && (
+          <PrTable prs={prs} checkMap={checkMap} />
+        )}
+        {!loading && !error && tab === 'issues' && (
+          <IssueTable issues={issues} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Guard cards ──────────────────────────────────────────────────────────────
+
+function EmptyCard({
+  message,
+  action,
+  onAction,
+}: {
+  message: string;
+  action?: string;
+  onAction?: () => void;
+}) {
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      justifyContent: 'center', height: '100%', gap: 12,
+    }}>
+      <div style={{ color: 'var(--text2)', fontSize: 14 }}>{message}</div>
+      {action && onAction && (
+        <button
+          onClick={onAction}
+          style={{
+            padding: '6px 16px', borderRadius: 'var(--r)',
+            background: 'var(--indigo-bg2)', color: 'var(--indigo)',
+            border: '1px solid var(--indigo-d)', fontSize: 12,
+          }}
+        >
+          {action}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function LoadingCard() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+      <div style={{ color: 'var(--text3)', fontSize: 12 }}>読み込み中…</div>
+    </div>
+  );
+}
+
+// ─── PR table ─────────────────────────────────────────────────────────────────
+
+function PrTable({
+  prs,
+  checkMap,
+}: {
+  prs: PullRequest[];
+  checkMap: Map<string, CiStatus>;
+}) {
+  if (prs.length === 0) {
+    return (
+      <div style={{ padding: 24, color: 'var(--text3)', fontSize: 12 }}>
+        オープンな PR はありません
+      </div>
+    );
+  }
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          {['CI', '#', 'TITLE', 'AUTHOR', 'BRANCH', 'UPDATED'].map((h) => (
+            <th
+              key={h}
+              style={{
+                fontSize: 10, fontWeight: 600, color: 'var(--text3)',
+                letterSpacing: '.08em', textAlign: 'left',
+                padding: '10px 8px', borderBottom: '1px solid var(--border2)',
+              }}
+            >
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {prs.map((pr) => (
+          <PrRow
+            key={pr.number}
+            pr={pr}
+            ciStatus={checkMap.get(pr.head_ref) ?? null}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function PrRow({ pr, ciStatus }: { pr: PullRequest; ciStatus: CiStatus }) {
+  const dotColor =
+    ciStatus === 'success' ? 'var(--green)'
+    : ciStatus === 'failure' ? 'var(--red)'
+    : ciStatus === 'pending' ? 'var(--amber)'
+    : 'var(--text3)';
+
+  return (
+    <tr style={{ borderBottom: '1px solid var(--border)' }}>
+      <td style={{ padding: '8px' }}>
+        <span
+          style={{
+            display: 'inline-block', width: 8, height: 8,
+            borderRadius: '50%', background: dotColor,
+          }}
+          title={ciStatus ?? 'unknown'}
+        />
+      </td>
+      <td style={{
+        padding: '8px',
+        fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: 'var(--text3)',
+      }}>
+        #{pr.number}
+      </td>
+      <td style={{
+        padding: '8px', fontSize: 12,
+        color: pr.draft ? 'var(--text2)' : 'var(--text1)',
+        maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>
+        {pr.draft && (
+          <span style={{
+            fontSize: 9, background: 'var(--bg4)', color: 'var(--text3)',
+            padding: '1px 5px', borderRadius: 3, marginRight: 6,
+          }}>
+            Draft
+          </span>
+        )}
+        {pr.title}
+      </td>
+      <td style={{ padding: '8px', fontSize: 11, color: 'var(--text2)' }}>
+        {pr.user_login}
+      </td>
+      <td style={{
+        padding: '8px',
+        fontFamily: 'var(--font-mono)', fontSize: 10,
+        color: 'var(--indigo)',
+        maxWidth: 140, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>
+        {pr.head_ref}
+      </td>
+      <td style={{ padding: '8px', fontSize: 10, color: 'var(--text3)' }}>
+        {relativeDate(pr.updated_at)}
+      </td>
+    </tr>
+  );
+}
+
+// ─── Issue table ──────────────────────────────────────────────────────────────
+
+function IssueTable({ issues }: { issues: Issue[] }) {
+  if (issues.length === 0) {
+    return (
+      <div style={{ padding: 24, color: 'var(--text3)', fontSize: 12 }}>
+        オープンな Issue はありません
+      </div>
+    );
+  }
+
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr>
+          {['#', 'TITLE', 'LABELS', 'AUTHOR', 'UPDATED'].map((h) => (
+            <th
+              key={h}
+              style={{
+                fontSize: 10, fontWeight: 600, color: 'var(--text3)',
+                letterSpacing: '.08em', textAlign: 'left',
+                padding: '10px 8px', borderBottom: '1px solid var(--border2)',
+              }}
+            >
+              {h}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {issues.map((issue) => (
+          <IssueRow key={issue.number} issue={issue} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function IssueRow({ issue }: { issue: Issue }) {
+  return (
+    <tr style={{ borderBottom: '1px solid var(--border)' }}>
+      <td style={{
+        padding: '8px',
+        fontFamily: 'var(--font-mono)', fontSize: 11,
+        color: 'var(--text3)',
+      }}>
+        #{issue.number}
+      </td>
+      <td style={{
+        padding: '8px', fontSize: 12, color: 'var(--text1)',
+        maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>
+        {issue.title}
+      </td>
+      <td style={{ padding: '8px' }}>
+        {issue.labels.map((l) => (
+          <span
+            key={l}
+            style={{
+              fontSize: 9, background: 'var(--bg4)', color: 'var(--text2)',
+              padding: '1px 5px', borderRadius: 3, marginRight: 3,
+            }}
+          >
+            {l}
+          </span>
+        ))}
+      </td>
+      <td style={{ padding: '8px', fontSize: 11, color: 'var(--text2)' }}>
+        {issue.user_login}
+      </td>
+      <td style={{ padding: '8px', fontSize: 10, color: 'var(--text3)' }}>
+        {relativeDate(issue.updated_at)}
+      </td>
+    </tr>
+  );
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+type CiStatus = 'success' | 'failure' | 'pending' | null;
+
+function deriveCheckStatus(runs: CheckRun[]): CiStatus {
+  if (runs.length === 0) return null;
+  if (runs.some((r) => r.status === 'in_progress' || r.status === 'queued')) return 'pending';
+  if (runs.some((r) =>
+    r.conclusion === 'failure' ||
+    r.conclusion === 'timed_out' ||
+    r.conclusion === 'action_required'
+  )) return 'failure';
+  if (runs.every((r) =>
+    r.conclusion === 'success' ||
+    r.conclusion === 'skipped' ||
+    r.conclusion === 'neutral' ||
+    r.conclusion === 'cancelled'
+  )) return 'success';
+  return null;
+}
+
+function relativeDate(iso: string): string {
+  const diff = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+  if (diff < 86_400) return `${Math.floor(diff / 3600)}h`;
+  if (diff < 604_800) return `${Math.floor(diff / 86_400)}d`;
+  return `${Math.floor(diff / 604_800)}w`;
+}

--- a/tasks.md
+++ b/tasks.md
@@ -137,14 +137,14 @@
 - [x] P2-02: `commands/github.rs` — `get_pull_requests` (GitHub REST API GET /repos/{o}/{r}/pulls)
 - [x] P2-03: `commands/github.rs` — `get_issues` (state: open/closed/all)
 - [x] P2-04: `commands/github.rs` — `get_check_runs` (CI ステータス取得)
-- [ ] P2-05: `src/views/PullRequests.tsx` — PR / Issue 一覧 + CI ステータスドット
-- [ ] P2-06: TanStack Query 導入 — GitHub API キャッシュ + 5分間隔自動リフレッシュ
+- [x] P2-05: `src/views/PullRequests.tsx` — PR / Issue 一覧 + CI ステータスドット
+- [x] P2-06: TanStack Query 導入 — GitHub API キャッシュ + 5分間隔自動リフレッシュ
 - [ ] P2-07: `commands/repo.rs` — `get_commit_graph` (d3 向け CommitNode 配列 + lane 計算)
 - [ ] P2-08: `src/views/Graph.tsx` — SVG コミットグラフ (d3 lane 計算 + 素 SVG 描画)
 - [ ] P2-09: `commands/dsx.rs` — `env_inject` (`dsx env run -- {cmd}`)
 - [ ] P2-10: `commands/dsx.rs` — `sys_update` (`dsx sys update --no-tui`)
 - [ ] P2-11: Settings 画面に sys_update ボタン追加
-- [ ] P2-12: PAT 未設定時の GitHub API エラーを graceful に処理 (PR ビュー無効化 + 設定案内)
+- [x] P2-12: PAT 未設定時の GitHub API エラーを graceful に処理 (PR ビュー無効化 + 設定案内)
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -174,6 +174,8 @@
 - [ ] P4-08: README / CHANGELOG 整備
 - [ ] P4-09: GitHub public release 公開 (v0.1.0)
 - [ ] P4-10: アクセシビリティ確認 (キーボードナビゲーション / フォーカス管理)
+- [ ] P4-11: `PullRequest` モデルに `head_sha` を追加し、CI check-runs のキーと API ref を SHA ベースに統一
+       (現在は `pr.number` をキャッシュキーに使用。fork PR で同名ブランチが重複する場合の完全な解決策として Phase 4 で対応)
 
 ---
 


### PR DESCRIPTION
## Summary

- **P2-06**: `main.tsx` に `QueryClientProvider` を追加（`staleTime=5min`, `retry=1` をデフォルト設定）
- **P2-05**: `src/views/PullRequests.tsx` を新規実装
  - PR タブ: 番号・タイトル・作者・ブランチ名・更新日時を表示
  - Issue タブ: 番号・タイトル・ラベル・作者・更新日時を表示
  - CI ステータスドット: `useQueries` で各 PR の `head_ref` に対して `get_check_runs` を並列呼び出し → 緑/黄/赤のドットで結果を表示
  - 5分間隔の自動リフレッシュ（`refetchInterval: STALE_MS`）
- **P2-12**: PAT 未設定 / `github_owner`・`github_repo` 未設定時の guard カード（Settings へ誘導）
- `App.tsx`: `prs` ルートの `PlaceholderView` を `PullRequests` に差し替え

## Test plan

- [x] PAT 未設定時に「Settings で設定する」カードが表示される
- [x] `github_owner`/`github_repo` 未設定のリポジトリで設定案内カードが表示される
- [x] PAT + リポジトリ設定済みで PR タブに一覧が表示される
- [x] CI ドットが success（緑）/ failure（赤）/ pending（黄）/ unknown（グレー）で表示される
- [x] Issues タブに切り替えると Issue 一覧が取得される
- [x] 5分後にバックグラウンドでデータが自動更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)