### PR TITLE
feat(p2-07/08): commit graph — lane assignment + SVG renderer

### DIFF
--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -190,13 +190,18 @@ pub fn get_commit_graph(
     let max = (limit.unwrap_or(200) as usize).min(MAX_COMMITS_LIMIT);
     let repo = Repository::open(&repo_path).map_err(|e| e.to_string())?;
 
-    // Build oid → ref-names map (branches, tags, HEAD).
+    // Build oid → ref-names map (local branches and tags only; remotes are
+    // excluded to avoid cluttering the graph badges with origin/... labels).
     let mut ref_map: HashMap<git2::Oid, Vec<String>> = HashMap::new();
     for r in repo.references().map_err(|e| e.to_string())? {
         let r = r.map_err(|e| e.to_string())?;
-        let Some(name) = r.shorthand() else { continue };
+        let Some(full_name) = r.name() else { continue };
+        if !full_name.starts_with("refs/heads/") && !full_name.starts_with("refs/tags/") {
+            continue;
+        }
+        let Some(short) = r.shorthand() else { continue };
         if let Ok(commit) = r.peel_to_commit() {
-            ref_map.entry(commit.id()).or_default().push(name.to_string());
+            ref_map.entry(commit.id()).or_default().push(short.to_string());
         }
     }
 
@@ -204,16 +209,27 @@ pub fn get_commit_graph(
     let mut walk = repo.revwalk().map_err(|e| e.to_string())?;
     walk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)
         .map_err(|e| e.to_string())?;
+    // Track whether we added any starting points to the revwalk.
+    let mut has_start = false;
     // push_glob may return NotFound on repos with no local branches (e.g. bare
-    // or freshly `git init`'d). Treat that as "no commits" rather than an error.
+    // or freshly `git init`'d). Treat that as "no branches" rather than an error.
     match walk.push_glob("refs/heads/*") {
-        Ok(()) => {}
-        Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(vec![]),
+        Ok(()) => {
+            has_start = true;
+        }
+        Err(e) if e.code() == git2::ErrorCode::NotFound => {
+            // No local branches; we'll still try HEAD below.
+        }
         Err(e) => return Err(e.to_string()),
     }
     // Also include HEAD in case of detached state.
     if let Ok(head) = repo.head().and_then(|h| h.peel_to_commit()) {
         let _ = walk.push(head.id());
+        has_start = true;
+    }
+    // If we have no starting points at all, there is nothing to walk.
+    if !has_start {
+        return Ok(vec![]);
     }
 
     // Lane assignment via the pure helper (testable without git2).

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -1,6 +1,7 @@
 use crate::config::load_config;
-use crate::models::{BranchInfo, DeleteResult, FetchResult, RepoInfo};
+use crate::models::{BranchInfo, CommitNode, DeleteResult, FetchResult, RepoInfo};
 use git2::{BranchType, Repository, StatusOptions};
+use std::collections::HashMap;
 
 // ─── list_repositories ───────────────────────────────────────────────────────
 
@@ -171,6 +172,112 @@ pub fn fetch_all(repo_path: String) -> Result<FetchResult, String> {
     }
 
     Ok(FetchResult { updated_refs })
+}
+
+// ─── get_commit_graph ─────────────────────────────────────────────────────────
+
+/// Returns up to `limit` commits (default 200) in topological order with lane
+/// assignments suitable for SVG column rendering.
+#[tauri::command]
+pub fn get_commit_graph(
+    repo_path: String,
+    limit: Option<u32>,
+) -> Result<Vec<CommitNode>, String> {
+    let max = limit.unwrap_or(200) as usize;
+    let repo = Repository::open(&repo_path).map_err(|e| e.to_string())?;
+
+    // Build oid → ref-names map (branches, tags, HEAD).
+    let mut ref_map: HashMap<git2::Oid, Vec<String>> = HashMap::new();
+    for r in repo.references().map_err(|e| e.to_string())? {
+        let r = r.map_err(|e| e.to_string())?;
+        let Some(name) = r.shorthand() else { continue };
+        if let Ok(commit) = r.peel_to_commit() {
+            ref_map.entry(commit.id()).or_default().push(name.to_string());
+        }
+    }
+
+    // Walk in topological + time order, starting from all local branches.
+    let mut walk = repo.revwalk().map_err(|e| e.to_string())?;
+    walk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)
+        .map_err(|e| e.to_string())?;
+    walk.push_glob("refs/heads/*").map_err(|e| e.to_string())?;
+    // Also include HEAD in case of detached state.
+    if let Ok(head) = repo.head().and_then(|h| h.peel_to_commit()) {
+        let _ = walk.push(head.id());
+    }
+
+    // Lane assignment.
+    // `lanes[i]` = the OID we are "waiting for" in lane i.
+    // None means the slot is free.
+    let mut lanes: Vec<Option<git2::Oid>> = Vec::new();
+    let mut nodes: Vec<CommitNode> = Vec::with_capacity(max);
+
+    for oid_result in walk.take(max) {
+        let oid = oid_result.map_err(|e| e.to_string())?;
+        let commit = repo.find_commit(oid).map_err(|e| e.to_string())?;
+        let parent_ids: Vec<git2::Oid> = commit.parent_ids().collect();
+
+        // Find which lane this commit belongs to.
+        let my_lane = if let Some(pos) = lanes.iter().position(|l| *l == Some(oid)) {
+            pos
+        } else {
+            // Commit not yet tracked — allocate a new (or free) lane.
+            lanes
+                .iter()
+                .position(|l| l.is_none())
+                .unwrap_or_else(|| {
+                    lanes.push(None);
+                    lanes.len() - 1
+                })
+        };
+
+        // Clear ALL slots pointing at this commit (common ancestor reachable
+        // from multiple branches).
+        for slot in lanes.iter_mut() {
+            if *slot == Some(oid) {
+                *slot = None;
+            }
+        }
+
+        // Slot my_lane now points to the first parent (continuing the lane),
+        // unless it is already tracked elsewhere.
+        if let Some(&first_parent) = parent_ids.first() {
+            if !lanes.contains(&Some(first_parent)) {
+                lanes[my_lane] = Some(first_parent);
+            }
+            // If first_parent is already tracked, my_lane stays None (lane ends here).
+        }
+
+        // Remaining parents each need their own lane (merge scenario).
+        for &parent_id in parent_ids.iter().skip(1) {
+            if !lanes.contains(&Some(parent_id)) {
+                let free = lanes
+                    .iter()
+                    .position(|l| l.is_none())
+                    .unwrap_or_else(|| {
+                        lanes.push(None);
+                        lanes.len() - 1
+                    });
+                lanes[free] = Some(parent_id);
+            }
+        }
+
+        let refs = ref_map.get(&oid).cloned().unwrap_or_default();
+        let oid_str = oid.to_string();
+
+        nodes.push(CommitNode {
+            short_oid: oid_str[..7].to_string(),
+            oid: oid_str,
+            summary: commit.summary().unwrap_or_default().to_string(),
+            author_name: commit.author().name().unwrap_or_default().to_string(),
+            timestamp: commit.time().seconds(),
+            parent_oids: parent_ids.iter().map(|id| id.to_string()).collect(),
+            refs,
+            lane: my_lane as u32,
+        });
+    }
+
+    Ok(nodes)
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -216,9 +216,7 @@ pub fn get_commit_graph(
         let _ = walk.push(head.id());
     }
 
-    // Lane assignment.
-    // `lanes[i]` = the OID we are "waiting for" in lane i.
-    // None means the slot is free.
+    // Lane assignment via the pure helper (testable without git2).
     let mut lanes: Vec<Option<git2::Oid>> = Vec::new();
     let mut nodes: Vec<CommitNode> = Vec::with_capacity(max);
 
@@ -227,50 +225,7 @@ pub fn get_commit_graph(
         let commit = repo.find_commit(oid).map_err(|e| e.to_string())?;
         let parent_ids: Vec<git2::Oid> = commit.parent_ids().collect();
 
-        // Find which lane this commit belongs to.
-        let my_lane = if let Some(pos) = lanes.iter().position(|l| *l == Some(oid)) {
-            pos
-        } else {
-            // Commit not yet tracked — allocate a new (or free) lane.
-            lanes
-                .iter()
-                .position(|l| l.is_none())
-                .unwrap_or_else(|| {
-                    lanes.push(None);
-                    lanes.len() - 1
-                })
-        };
-
-        // Clear ALL slots pointing at this commit (common ancestor reachable
-        // from multiple branches).
-        for slot in lanes.iter_mut() {
-            if *slot == Some(oid) {
-                *slot = None;
-            }
-        }
-
-        // Slot my_lane now points to the first parent (continuing the lane),
-        // unless it is already tracked elsewhere.
-        if let Some(&first_parent) = parent_ids.first() {
-            if !lanes.contains(&Some(first_parent)) {
-                lanes[my_lane] = Some(first_parent);
-            }
-            // If first_parent is already tracked, my_lane stays None (lane ends here).
-        }
-
-        // Remaining parents each need their own lane (merge scenario).
-        for &parent_id in parent_ids.iter().skip(1) {
-            if !lanes.contains(&Some(parent_id)) {
-                let free = lanes
-                    .iter()
-                    .position(|l| l.is_none())
-                    .unwrap_or_else(|| {
-                        lanes.push(None);
-                        lanes.len() - 1
-                    });
-                lanes[free] = Some(parent_id);
-            }
-        }
+        let my_lane = assign_lane(&mut lanes, &oid, &parent_ids);
 
         let refs = ref_map.get(&oid).cloned().unwrap_or_default();
         let oid_str = oid.to_string();
@@ -376,4 +331,109 @@ fn upstream_ahead_behind(repo: &Repository, branch: &git2::Branch) -> (u32, u32)
         Some((a as u32, b as u32))
     })()
     .unwrap_or((0, 0))
+}
+
+/// Assigns a display lane (column index) for a commit in a topological walk.
+///
+/// `lanes` is a slot array where each entry is either `None` (free) or
+/// `Some(oid)` meaning "this slot is reserved for the commit with that OID".
+/// The function updates `lanes` in-place so callers can re-use the same vec
+/// across the entire walk.
+///
+/// Generic over `Id` so the algorithm can be unit-tested with plain integers
+/// without pulling in git2.
+fn assign_lane<Id>(lanes: &mut Vec<Option<Id>>, id: &Id, parents: &[Id]) -> usize
+where
+    Id: PartialEq + Clone,
+{
+    // Find (or allocate) the slot reserved for this commit.
+    let my_lane = if let Some(pos) = lanes.iter().position(|l| l.as_ref() == Some(id)) {
+        pos
+    } else {
+        lanes.iter().position(|l| l.is_none()).unwrap_or_else(|| {
+            lanes.push(None);
+            lanes.len() - 1
+        })
+    };
+
+    // Free all slots pointing to this commit.
+    for slot in lanes.iter_mut() {
+        if slot.as_ref() == Some(id) {
+            *slot = None;
+        }
+    }
+
+    // Reserve my_lane for the first parent (continuing the same line).
+    if let Some(first) = parents.first() {
+        if !lanes.contains(&Some(first.clone())) {
+            lanes[my_lane] = Some(first.clone());
+        }
+    }
+
+    // Allocate a new slot for each additional parent (branch lines).
+    for parent in parents.iter().skip(1) {
+        if !lanes.contains(&Some(parent.clone())) {
+            let free = lanes.iter().position(|l| l.is_none()).unwrap_or_else(|| {
+                lanes.push(None);
+                lanes.len() - 1
+            });
+            lanes[free] = Some(parent.clone());
+        }
+    }
+
+    my_lane
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::assign_lane;
+
+    fn run(commits: &[(u32, &[u32])]) -> Vec<usize> {
+        let mut lanes: Vec<Option<u32>> = Vec::new();
+        commits
+            .iter()
+            .map(|(id, parents)| assign_lane(&mut lanes, id, parents))
+            .collect()
+    }
+
+    #[test]
+    fn lane_single_commit() {
+        assert_eq!(run(&[(1, &[])]), vec![0]);
+    }
+
+    #[test]
+    fn lane_empty_input() {
+        assert_eq!(run(&[]), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn lane_linear_history() {
+        // A→B→C (topological order: A first)
+        let result = run(&[(3, &[2]), (2, &[1]), (1, &[])]);
+        assert_eq!(result, vec![0, 0, 0]);
+    }
+
+    #[test]
+    fn lane_merge_and_rejoin() {
+        // Merge commit M has two parents: A (lane 0) and B (lane 1).
+        // After M both lines rejoin on lane 0.
+        //   M(0) -> A(0), B(1)
+        //   A(0) -> root(0)
+        //   B(1) -> root(0)
+        //   root(0) -> []
+        let result = run(&[(10, &[8, 9]), (8, &[7]), (9, &[7]), (7, &[])]);
+        assert_eq!(result, vec![0, 0, 1, 0]);
+    }
+
+    #[test]
+    fn lane_unseen_branch_tip_gets_new_lane() {
+        // Two independent branch tips before they converge.
+        //   tip_a(0) -> base(0)
+        //   tip_b(1) -> base(0)   ← base already claimed by lane 0
+        //   base(0)  -> []
+        let result = run(&[(1, &[3]), (2, &[3]), (3, &[])]);
+        assert_eq!(result, vec![0, 1, 0]);
+    }
 }

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -176,14 +176,18 @@ pub fn fetch_all(repo_path: String) -> Result<FetchResult, String> {
 
 // ─── get_commit_graph ─────────────────────────────────────────────────────────
 
+/// Hard upper bound on commit graph size to prevent accidental large revwalks.
+const MAX_COMMITS_LIMIT: usize = 10_000;
+
 /// Returns up to `limit` commits (default 200) in topological order with lane
 /// assignments suitable for SVG column rendering.
+/// The requested `limit` is clamped to `MAX_COMMITS_LIMIT`.
 #[tauri::command]
 pub fn get_commit_graph(
     repo_path: String,
     limit: Option<u32>,
 ) -> Result<Vec<CommitNode>, String> {
-    let max = limit.unwrap_or(200) as usize;
+    let max = (limit.unwrap_or(200) as usize).min(MAX_COMMITS_LIMIT);
     let repo = Repository::open(&repo_path).map_err(|e| e.to_string())?;
 
     // Build oid → ref-names map (branches, tags, HEAD).
@@ -200,7 +204,13 @@ pub fn get_commit_graph(
     let mut walk = repo.revwalk().map_err(|e| e.to_string())?;
     walk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)
         .map_err(|e| e.to_string())?;
-    walk.push_glob("refs/heads/*").map_err(|e| e.to_string())?;
+    // push_glob may return NotFound on repos with no local branches (e.g. bare
+    // or freshly `git init`'d). Treat that as "no commits" rather than an error.
+    match walk.push_glob("refs/heads/*") {
+        Ok(()) => {}
+        Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(vec![]),
+        Err(e) => return Err(e.to_string()),
+    }
     // Also include HEAD in case of detached state.
     if let Ok(head) = repo.head().and_then(|h| h.peel_to_commit()) {
         let _ = walk.push(head.id());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,10 @@ use commands::{
     },
     dsx::{dsx_check, repo_cleanup, repo_cleanup_preview, repo_update},
     github::{get_check_runs, get_issues, get_pull_requests},
-    repo::{delete_branches, fetch_all, get_branches, get_repo_status, list_repositories},
+    repo::{
+        delete_branches, fetch_all, get_branches, get_commit_graph, get_repo_status,
+        list_repositories,
+    },
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -37,6 +40,7 @@ pub fn run() {
             get_branches,
             delete_branches,
             fetch_all,
+            get_commit_graph,
             // dsx
             dsx_check,
             repo_update,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -42,8 +42,7 @@ pub struct BranchInfo {
     pub remote_name: Option<String>,
 }
 
-/// Commit node for the Graph view (d3 lane rendering). Used in Phase 2.
-#[allow(dead_code)]
+/// Commit node for the Graph view (lane rendering).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitNode {
     pub oid: String,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ToastContainer from './components/Toast';
 import ErrorBoundary from './components/ErrorBoundary';
 import Overview from './views/Overview';
 import Branches from './views/Branches';
+import Graph from './views/Graph';
 import PullRequests from './views/PullRequests';
 import Cleanup from './views/Cleanup';
 import Settings from './views/Settings';
@@ -64,7 +65,9 @@ export default function App() {
         {activeView === 'branches' && (
           <ErrorBoundary key="branches" viewName="Branches"><Branches /></ErrorBoundary>
         )}
-        {activeView === 'graph'   && <PlaceholderView label="Commit Graph" note="Implemented in Phase 2" />}
+        {activeView === 'graph'   && (
+          <ErrorBoundary key="graph" viewName="Commit Graph"><Graph /></ErrorBoundary>
+        )}
         {activeView === 'prs'     && (
           <ErrorBoundary key="prs" viewName="PR / Issues"><PullRequests /></ErrorBoundary>
         )}
@@ -76,21 +79,6 @@ export default function App() {
         )}
       </main>
       <ToastContainer />
-    </div>
-  );
-}
-
-function PlaceholderView({ label, note }: { label: string; note: string }) {
-  return (
-    <div style={{
-      display: 'flex', flexDirection: 'column',
-      alignItems: 'center', justifyContent: 'center',
-      height: '100%', gap: 8,
-    }}>
-      <div style={{ fontFamily: 'var(--font-display)', fontSize: 20, color: 'var(--text2)' }}>
-        {label}
-      </div>
-      <div style={{ fontSize: 12, color: 'var(--text3)' }}>{note}</div>
     </div>
   );
 }

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -7,6 +7,7 @@ import type {
   AppConfig,
   BranchInfo,
   CheckRun,
+  CommitNode,
   DeleteResult,
   DsxOutput,
   DsxStatus,
@@ -55,6 +56,9 @@ export const deleteBranches = (repo_path: string, names: string[]) =>
 
 export const fetchAll = (repo_path: string) =>
   tauriInvoke<FetchResult>('fetch_all', { repo_path });
+
+export const getCommitGraph = (repo_path: string, limit?: number) =>
+  tauriInvoke<CommitNode[]>('get_commit_graph', { repo_path, limit });
 
 // ─── GitHub PAT ──────────────────────────────────────────────────────────────
 

--- a/src/views/Graph.tsx
+++ b/src/views/Graph.tsx
@@ -1,0 +1,202 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRepoStore } from '../stores/repoStore';
+import AppBar from '../components/AppBar';
+import { getCommitGraph } from '../lib/invoke';
+import type { CommitNode } from '../types';
+
+// ─── Layout constants ─────────────────────────────────────────────────────────
+
+const ROW_H = 26;
+const LANE_W = 16;
+const DOT_R = 4;
+
+// Hardcoded hex values matching design tokens (CSS vars don't resolve in SVG attrs)
+const LANE_COLORS = ['#818cf8', '#4ade80', '#fbbf24', '#f87171', '#c084fc'];
+
+function laneColor(lane: number): string {
+  return LANE_COLORS[lane % LANE_COLORS.length];
+}
+function dotX(lane: number): number { return lane * LANE_W + LANE_W / 2; }
+function dotY(row: number): number  { return row  * ROW_H  + ROW_H  / 2; }
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function Graph() {
+  const { selectedRepo } = useRepoStore();
+
+  const { data: commits = [], isLoading, error } = useQuery({
+    queryKey: ['graph', selectedRepo?.path],
+    queryFn: () => getCommitGraph(selectedRepo!.path),
+    enabled: !!selectedRepo,
+    staleTime: 30_000,
+  });
+
+  if (!selectedRepo) {
+    return <CenteredMsg>リポジトリを選択してください</CenteredMsg>;
+  }
+  if (isLoading) {
+    return <CenteredMsg muted>読み込み中…</CenteredMsg>;
+  }
+  if (error) {
+    return <CenteredMsg color="#f87171">{String(error)}</CenteredMsg>;
+  }
+  if (commits.length === 0) {
+    return <CenteredMsg muted>コミットがありません</CenteredMsg>;
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <AppBar
+        path={
+          <>
+            <span style={{ color: 'var(--text2)' }}>{selectedRepo.name}</span>
+            {' '}· {commits.length} commits
+          </>
+        }
+      />
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <CommitGraph commits={commits} />
+      </div>
+    </div>
+  );
+}
+
+// ─── SVG graph ────────────────────────────────────────────────────────────────
+
+function CommitGraph({ commits }: { commits: CommitNode[] }) {
+  const maxLane  = commits.reduce((m, c) => Math.max(m, c.lane), 0);
+  const laneAreaW = (maxLane + 1) * LANE_W;
+  const textX     = laneAreaW + 12;
+  const svgW      = textX + 560;
+  const svgH      = commits.length * ROW_H + 8;
+
+  // Pre-compute row index for each OID so we can draw edges to parents.
+  const rowOf = new Map(commits.map((c, i) => [c.oid, i]));
+
+  return (
+    <svg
+      width={svgW}
+      height={svgH}
+      style={{ display: 'block', fontFamily: 'var(--font-mono)' }}
+    >
+      {/* ── Edges (drawn first, behind dots) ─────────────────────────────── */}
+      {commits.map((commit, row) =>
+        commit.parent_oids.map((parentOid) => {
+          const parentRow = rowOf.get(parentOid);
+          if (parentRow === undefined) return null;
+          const parent = commits[parentRow];
+          const x1 = dotX(commit.lane), y1 = dotY(row);
+          const x2 = dotX(parent.lane),  y2 = dotY(parentRow);
+          const mid = (y1 + y2) / 2;
+          return (
+            <path
+              key={`${commit.oid}-${parentOid}`}
+              d={`M ${x1} ${y1} C ${x1} ${mid} ${x2} ${mid} ${x2} ${y2}`}
+              fill="none"
+              stroke={laneColor(commit.lane)}
+              strokeWidth={1.5}
+              opacity={0.45}
+            />
+          );
+        })
+      )}
+
+      {/* ── Dots + text ───────────────────────────────────────────────────── */}
+      {commits.map((commit, row) => (
+        <CommitRow
+          key={commit.oid}
+          commit={commit}
+          row={row}
+          textX={textX}
+          svgW={svgW}
+        />
+      ))}
+    </svg>
+  );
+}
+
+// ─── Single commit row ────────────────────────────────────────────────────────
+
+function CommitRow({
+  commit,
+  row,
+  textX,
+  svgW,
+}: {
+  commit: CommitNode;
+  row: number;
+  textX: number;
+  svgW: number;
+}) {
+  const cx = dotX(commit.lane);
+  const cy = dotY(row);
+  const color = laneColor(commit.lane);
+
+  const date = new Date(commit.timestamp * 1000);
+  const dateStr = `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+
+  // Text columns (relative to textX):
+  //   0      : short SHA (7 chars ≈ 54px)
+  //   62     : refs + summary
+  //   440    : date
+  const shaX     = textX;
+  const summaryX = textX + 62;
+  const dateX    = svgW - 80;
+
+  // Truncate summary so it doesn't overflow into the date column.
+  const maxSummaryChars = 55;
+  const summary = commit.summary.length > maxSummaryChars
+    ? commit.summary.slice(0, maxSummaryChars - 1) + '…'
+    : commit.summary;
+
+  return (
+    <g>
+      {/* Lane dot */}
+      <circle cx={cx} cy={cy} r={DOT_R} fill={color} />
+
+      {/* Short SHA */}
+      <text x={shaX} y={cy + 4} fontSize={10} fill="#4a5568">
+        {commit.short_oid}
+      </text>
+
+      {/* Ref badges (one tspan each) then summary */}
+      <text x={summaryX} y={cy + 4} fontSize={11}>
+        {commit.refs.map((r) => (
+          <tspan key={r} fill="#818cf8">[{r}] </tspan>
+        ))}
+        <tspan fill="#e2e8f0">{summary}</tspan>
+      </text>
+
+      {/* Date */}
+      <text x={dateX} y={cy + 4} fontSize={10} fill="#4a5568">
+        {dateStr}
+      </text>
+    </g>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function CenteredMsg({
+  children,
+  color = '#94a3b8',
+  muted,
+}: {
+  children: React.ReactNode;
+  color?: string;
+  muted?: boolean;
+}) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      height: '100%', fontSize: 14,
+      color: muted ? 'var(--text3)' : color,
+    }}>
+      {children}
+    </div>
+  );
+}

--- a/src/views/Graph.tsx
+++ b/src/views/Graph.tsx
@@ -161,8 +161,8 @@ function CommitRow({
 
       {/* Ref badges (one tspan each) then summary */}
       <text x={summaryX} y={cy + 4} fontSize={11}>
-        {commit.refs.map((r) => (
-          <tspan key={r} fill="#818cf8">[{r}] </tspan>
+        {commit.refs.map((r, idx) => (
+          <tspan key={`${r}-${idx}`} fill="#818cf8">[{r}] </tspan>
         ))}
         <tspan fill="#e2e8f0">{summary}</tspan>
       </text>

--- a/tasks.md
+++ b/tasks.md
@@ -139,8 +139,8 @@
 - [x] P2-04: `commands/github.rs` — `get_check_runs` (CI ステータス取得)
 - [x] P2-05: `src/views/PullRequests.tsx` — PR / Issue 一覧 + CI ステータスドット
 - [x] P2-06: TanStack Query 導入 — GitHub API キャッシュ + 5分間隔自動リフレッシュ
-- [ ] P2-07: `commands/repo.rs` — `get_commit_graph` (d3 向け CommitNode 配列 + lane 計算)
-- [ ] P2-08: `src/views/Graph.tsx` — SVG コミットグラフ (d3 lane 計算 + 素 SVG 描画)
+- [x] P2-07: `commands/repo.rs` — `get_commit_graph` (d3 向け CommitNode 配列 + lane 計算)
+- [x] P2-08: `src/views/Graph.tsx` — SVG コミットグラフ (d3 lane 計算 + 素 SVG 描画)
 - [ ] P2-09: `commands/dsx.rs` — `env_inject` (`dsx env run -- {cmd}`)
 - [ ] P2-10: `commands/dsx.rs` — `sys_update` (`dsx sys update --no-tui`)
 - [ ] P2-11: Settings 画面に sys_update ボタン追加


### PR DESCRIPTION
## Summary

- **P2-07**: `get_commit_graph` Tauri コマンド（Rust）
  - `revwalk` を `TOPOLOGICAL | TIME` で実行し、全ローカルブランチの履歴を走査
  - スロットベースのレーン割り当てアルゴリズム: 共通祖先に複数レーンが到達した場合に衝突しないよう、コミット処理時に全スロットをクリアしてから親を伝播
  - デフォルト最大 200 コミット、`limit` パラメータで上書き可能
  - `CommitNode` の `#[allow(dead_code)]` を除去

- **P2-08**: `src/views/Graph.tsx`（フロントエンド）
  - 純粋 SVG レンダラー: ベジェ曲線のエッジ + 色付きレーンドット
  - テキスト列: short SHA / ref バッジ（紫）/ コミットサマリー / 日付
  - TanStack Query で staleTime=30s（ローカル git 操作なのでネットワーク不要）
  - リポジトリ未選択 / 読み込み中 / エラー時のガードカード

- `App.tsx`: Graph プレースホルダーを実装に差し替え、不要になった `PlaceholderView` を削除

## Test plan

- [ ] Graph ビューに切り替えるとコミット一覧が SVG で表示される
- [ ] マージコミット（複数親）でレーンが分岐し、ベジェ曲線でつながる
- [ ] ブランチ名がコミットドットの横に紫バッジで表示される
- [ ] リポジトリ未選択時に「リポジトリを選択してください」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)