### PR TITLE
feat(dsx): add env_inject and sys_update commands + Settings Update button (P2-09/10/11)

### DIFF
--- a/src-tauri/src/commands/dsx.rs
+++ b/src-tauri/src/commands/dsx.rs
@@ -90,6 +90,35 @@ pub async fn repo_cleanup(app: AppHandle, repo_path: String) -> Result<DsxOutput
     run_dsx_with_events(&app, &repo_path, &["repo", "cleanup"]).await
 }
 
+// ─── env_inject ───────────────────────────────────────────────────────────────
+
+/// Runs `dsx env run -- <cmd>` in the given repository directory.
+///
+/// Streams stdout back as `dsx_progress` events so the UI can display
+/// real-time output for long-running environment-injected commands.
+#[tauri::command]
+pub async fn env_inject(
+    app: AppHandle,
+    repo_path: String,
+    cmd: String,
+) -> Result<DsxOutput, String> {
+    let cmd_parts: Vec<&str> = cmd.split_whitespace().collect();
+    let mut args = vec!["env", "run", "--"];
+    args.extend_from_slice(&cmd_parts);
+    run_dsx_with_events(&app, &repo_path, &args).await
+}
+
+// ─── sys_update ───────────────────────────────────────────────────────────────
+
+/// Runs `dsx sys update --no-tui` to upgrade dsx-managed tools.
+///
+/// Does not require a specific repository directory. Progress lines are
+/// streamed via `dsx_progress` events the same way as `repo_update`.
+#[tauri::command]
+pub async fn sys_update(app: AppHandle) -> Result<DsxOutput, String> {
+    run_dsx_with_events(&app, ".", &["sys", "update", "--no-tui"]).await
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Runs a dsx command, streaming stdout lines as `dsx_progress` events to the
@@ -215,5 +244,36 @@ mod tests {
         let path = which_dsx();
         assert!(path.is_some(), "which_dsx should return a path");
         assert!(!path.unwrap().is_empty());
+    }
+
+    /// `env_inject` に渡すコマンド文字列が空白で正しく分割されることを確認する。
+    /// dsx の実際の呼び出しではなく、引数分割ロジックのみを検証する。
+    #[test]
+    fn env_inject_cmd_splits_into_args() {
+        let cmd = "npm install --frozen-lockfile";
+        let parts: Vec<&str> = cmd.split_whitespace().collect();
+        assert_eq!(parts, vec!["npm", "install", "--frozen-lockfile"]);
+
+        let mut args = vec!["env", "run", "--"];
+        args.extend_from_slice(&parts);
+        assert_eq!(
+            args,
+            vec!["env", "run", "--", "npm", "install", "--frozen-lockfile"]
+        );
+    }
+
+    /// dsx が利用可能な場合に `sys update --no-tui` が存在するサブコマンドとして
+    /// 認識されることを確認する（`--help` でサブコマンド一覧が取れれば十分）。
+    #[test]
+    fn run_dsx_sync_help_succeeds_when_available() {
+        if !dsx_check().available {
+            return;
+        }
+        let result = run_dsx_sync(".", &["--help"]);
+        let output = result.expect("dsx --help should not error");
+        // dsx --help は exit 0 または非ゼロを返す実装に依存するが
+        // 少なくとも stdout/stderr のどちらかに出力があることを確認
+        let has_output = !output.stdout.is_empty() || !output.stderr.is_empty();
+        assert!(has_output, "dsx --help should produce some output");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use commands::{
         add_repository, delete_github_pat, get_config, has_github_pat, remove_repository,
         scan_directory, set_github_pat, update_settings,
     },
-    dsx::{dsx_check, repo_cleanup, repo_cleanup_preview, repo_update},
+    dsx::{dsx_check, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
     repo::{
         delete_branches, fetch_all, get_branches, get_commit_graph, get_repo_status,
@@ -46,6 +46,8 @@ pub fn run() {
             repo_update,
             repo_cleanup_preview,
             repo_cleanup,
+            env_inject,
+            sys_update,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Arbor");

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -99,3 +99,9 @@ export const repoCleanupPreview = (repo_path: string) =>
 
 export const repoCleanup = (repo_path: string) =>
   tauriInvoke<DsxOutput>('repo_cleanup', { repo_path });
+
+export const envInject = (repo_path: string, cmd: string) =>
+  tauriInvoke<DsxOutput>('env_inject', { repo_path, cmd });
+
+export const sysUpdate = () =>
+  tauriInvoke<DsxOutput>('sys_update');

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import Settings from './Settings';
+import ToastContainer from '../components/Toast';
+import * as invoke from '../lib/invoke';
+import { useUiStore } from '../stores/uiStore';
+
+// デフォルトの invoke モックを設定する
+const mockDsxCheck = vi.spyOn(invoke, 'dsxCheck');
+const mockGetConfig = vi.spyOn(invoke, 'getConfig');
+const mockHasGithubPat = vi.spyOn(invoke, 'hasGithubPat');
+const mockSysUpdate = vi.spyOn(invoke, 'sysUpdate');
+
+const availableDsxStatus = { available: true, version: 'v0.2.3', path: '/usr/local/bin/dsx' };
+const unavailableDsxStatus = { available: false, version: null, path: null };
+
+const mockConfig = {
+  repositories: [],
+  settings: { stale_threshold_days: 30, fetch_on_startup: false },
+  ai: { provider: 'ollama', model: 'qwen3.5:latest', ollama_url: 'http://localhost:11434' },
+  github_keychain_key: 'arbor_github_pat',
+};
+
+function renderWithToast() {
+  return render(
+    <>
+      <Settings />
+      <ToastContainer />
+    </>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => { useUiStore.setState({ toasts: [] }); });
+  mockGetConfig.mockResolvedValue(mockConfig as never);
+  mockHasGithubPat.mockResolvedValue(false as never);
+  mockDsxCheck.mockResolvedValue(availableDsxStatus as never);
+  mockSysUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 } as never);
+});
+
+describe('Settings — dsx CLI section', () => {
+  it('dsx が利用可能な場合にバージョンを表示する', async () => {
+    render(<Settings />);
+    await screen.findByText(/v0\.2\.3/);
+    expect(screen.getByText(/v0\.2\.3/)).toBeInTheDocument();
+  });
+
+  it('dsx が利用可能な場合に Update ボタンを表示する', async () => {
+    render(<Settings />);
+    await screen.findByRole('button', { name: 'Update' });
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('dsx が利用不可の場合に Update ボタンを表示しない', async () => {
+    mockDsxCheck.mockResolvedValue(unavailableDsxStatus as never);
+    render(<Settings />);
+    // インストール案内テキストが出るまで待つ
+    await screen.findByText(/dsx が見つかりません/);
+    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+  });
+
+  it('Update ボタンをクリックすると sysUpdate が呼ばれる', async () => {
+    render(<Settings />);
+    const btn = await screen.findByRole('button', { name: 'Update' });
+    await userEvent.click(btn);
+    expect(mockSysUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('sysUpdate 完了後に dsxCheck を再呼び出しする', async () => {
+    render(<Settings />);
+    const btn = await screen.findByRole('button', { name: 'Update' });
+    await userEvent.click(btn);
+    await waitFor(() => {
+      // 初回 mount + update 後の再チェックで計 2 回呼ばれる
+      expect(mockDsxCheck).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('sysUpdate が失敗した場合にエラートーストを表示する', async () => {
+    mockSysUpdate.mockRejectedValue(new Error('network error') as never);
+    renderWithToast();
+    const btn = await screen.findByRole('button', { name: 'Update' });
+    await userEvent.click(btn);
+    // Toast に error メッセージが表示される（String(Error) → "Error: network error"）
+    await screen.findByText('Error: network error');
+  });
+});

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus } from '../types';
 
@@ -14,6 +14,7 @@ export default function Settings() {
   const [patStored, setPatStored] = useState<boolean | null>(null);
   const [patInput, setPatInput]   = useState('');
   const [patLoading, setPatLoading] = useState(false);
+  const [sysUpdating, setSysUpdating] = useState(false);
 
   useEffect(() => {
     getConfig().then(setConfig).catch((e) => addToast(String(e), 'error'));
@@ -65,6 +66,21 @@ export default function Settings() {
     }
   };
 
+  const handleSysUpdate = async () => {
+    setSysUpdating(true);
+    try {
+      await sysUpdate();
+      addToast('dsx sys update 完了', 'success');
+      // バージョンを再取得して表示を更新する
+      const status = await dsxCheck();
+      setDsxStatus(status);
+    } catch (e) {
+      addToast(String(e), 'error');
+    } finally {
+      setSysUpdating(false);
+    }
+  };
+
   const handleRemoveRepo = async (path: string) => {
     try {
       const updated = await removeRepository(path);
@@ -90,11 +106,19 @@ export default function Settings() {
           <SectionTitle>dsx CLI</SectionTitle>
           {dsxStatus ? (
             dsxStatus.available ? (
-              <div style={{ fontSize: 12, color: 'var(--green)' }}>
-                ✓ dsx {dsxStatus.version} &nbsp;·&nbsp;
-                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text3)' }}>
-                  {dsxStatus.path}
-                </span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{ fontSize: 12, color: 'var(--green)', flex: 1 }}>
+                  ✓ dsx {dsxStatus.version} &nbsp;·&nbsp;
+                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text3)' }}>
+                    {dsxStatus.path}
+                  </span>
+                </div>
+                <AppBtn
+                  onClick={handleSysUpdate}
+                  disabled={sysUpdating}
+                >
+                  {sysUpdating ? 'Updating…' : 'Update'}
+                </AppBtn>
               </div>
             ) : (
               <div style={{

--- a/tasks.md
+++ b/tasks.md
@@ -141,9 +141,9 @@
 - [x] P2-06: TanStack Query 導入 — GitHub API キャッシュ + 5分間隔自動リフレッシュ
 - [x] P2-07: `commands/repo.rs` — `get_commit_graph` (d3 向け CommitNode 配列 + lane 計算)
 - [x] P2-08: `src/views/Graph.tsx` — SVG コミットグラフ (d3 lane 計算 + 素 SVG 描画)
-- [ ] P2-09: `commands/dsx.rs` — `env_inject` (`dsx env run -- {cmd}`)
-- [ ] P2-10: `commands/dsx.rs` — `sys_update` (`dsx sys update --no-tui`)
-- [ ] P2-11: Settings 画面に sys_update ボタン追加
+- [x] P2-09: `commands/dsx.rs` — `env_inject` (`dsx env run -- {cmd}`)
+- [x] P2-10: `commands/dsx.rs` — `sys_update` (`dsx sys update --no-tui`)
+- [x] P2-11: Settings 画面に sys_update ボタン追加
 - [x] P2-12: PAT 未設定時の GitHub API エラーを graceful に処理 (PR ビュー無効化 + 設定案内)
 
 ---


### PR DESCRIPTION
## Summary

- **P2-09** `env_inject(repo_path, cmd)` — `dsx env run -- <cmd>` をストリーミング実行。コマンド文字列を空白分割して `--` セパレータ以降に渡す
- **P2-10** `sys_update()` — `dsx sys update --no-tui` をストリーミング実行。リポジトリパス不要
- **P2-11** Settings 画面の dsx CLI セクションに **Update** ボタンを追加。クリック後に `dsxCheck` を再呼び出ししてバージョン表示を更新する

## Changes

| File | Description |
|------|-------------|
| `src-tauri/src/commands/dsx.rs` | `env_inject` / `sys_update` コマンド追加 + ユニットテスト 2 件 |
| `src-tauri/src/lib.rs` | `invoke_handler!` に両コマンドを登録 |
| `src/lib/invoke.ts` | `envInject` / `sysUpdate` ラッパー追加 |
| `src/views/Settings.tsx` | dsx CLI セクションに Update ボタン追加 |
| `src/views/Settings.test.tsx` | 新規 — Settings コンポーネントのテスト 6 件 |

## Test plan

- [x] `cargo test` — 26 tests passed (including `env_inject_cmd_splits_into_args`, `run_dsx_sync_help_succeeds_when_available`)
- [x] `npm test` — 34 tests passed (including 6 new Settings tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)