### PR TITLE
fix(ui): UI bug fixes — button placement, camelCase invoke, Cleanup scope, PAT check

### DIFF
--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -150,3 +150,44 @@ pub fn update_settings(
     save_config(&config)?;
     Ok(config)
 }
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    /// キーチェーンの書き込み → 読み取り → 削除が正常に動作することを確認する。
+    /// キーチェーンが利用できない環境（CI サービスアカウント等）ではスキップする。
+    #[test]
+    fn keyring_roundtrip() {
+        const SERVICE: &str = "arbor_keyring_test";
+        const USER: &str = "test";
+        const SECRET: &str = "roundtrip_secret_12345";
+
+        let entry = match keyring::Entry::new(SERVICE, USER) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("keyring::Entry::new failed ({e}) — skipping");
+                return;
+            }
+        };
+
+        // 前回テストの残骸を削除
+        let _ = entry.delete_credential();
+
+        if let Err(e) = entry.set_password(SECRET) {
+            eprintln!("set_password failed ({e}) — keyring not functional, skipping");
+            return;
+        }
+
+        match entry.get_password() {
+            Ok(val) => {
+                let _ = entry.delete_credential();
+                assert_eq!(val, SECRET, "キーチェーンの読み取り値が書き込み値と一致しない");
+            }
+            Err(e) => {
+                let _ = entry.delete_credential();
+                panic!("set_password は成功したが get_password が失敗: {e}");
+            }
+        }
+    }
+}

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -156,8 +156,10 @@ pub fn update_settings(
 #[cfg(test)]
 mod tests {
     /// キーチェーンの書き込み → 読み取り → 削除が正常に動作することを確認する。
-    /// キーチェーンが利用できない環境（CI サービスアカウント等）ではスキップする。
+    /// 実際の OS キーチェーンに書き込むため、デフォルトでは #[ignore] にする。
+    /// `cargo test -- --ignored keyring_roundtrip` で明示的に実行すること。
     #[test]
+    #[ignore = "実 OS キーチェーンへのアクセスが必要。cargo test -- --ignored で実行"]
     fn keyring_roundtrip() {
         const SERVICE: &str = "arbor_keyring_test";
         const USER: &str = "test";

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -1,6 +1,9 @@
 /**
  * Type-safe wrappers around @tauri-apps/api/core `invoke`.
  * All commands mirror the Tauri command names in src-tauri/src/commands/.
+ *
+ * NOTE: Tauri v2 IPC converts camelCase (JS) ↔ snake_case (Rust) automatically.
+ * All multi-word argument keys must be camelCase on the JS side.
  */
 import { invoke as tauriInvoke } from '@tauri-apps/api/core';
 import type {
@@ -25,8 +28,8 @@ export const getConfig = () =>
 export const addRepository = (args: {
   path: string;
   name: string;
-  github_owner?: string;
-  github_repo?: string;
+  githubOwner?: string;
+  githubRepo?: string;
 }) => tauriInvoke<AppConfig>('add_repository', args);
 
 export const removeRepository = (path: string) =>
@@ -36,8 +39,8 @@ export const scanDirectory = (root: string) =>
   tauriInvoke<string[]>('scan_directory', { root });
 
 export const updateSettings = (args: {
-  stale_threshold_days?: number;
-  fetch_on_startup?: boolean;
+  staleThresholdDays?: number;
+  fetchOnStartup?: boolean;
 }) => tauriInvoke<AppConfig>('update_settings', args);
 
 // ─── Repo / git2 ─────────────────────────────────────────────────────────────
@@ -45,20 +48,20 @@ export const updateSettings = (args: {
 export const listRepositories = () =>
   tauriInvoke<RepoInfo[]>('list_repositories');
 
-export const getRepoStatus = (repo_path: string) =>
-  tauriInvoke<RepoInfo>('get_repo_status', { repo_path });
+export const getRepoStatus = (repoPath: string) =>
+  tauriInvoke<RepoInfo>('get_repo_status', { repoPath });
 
-export const getBranches = (repo_path: string) =>
-  tauriInvoke<BranchInfo[]>('get_branches', { repo_path });
+export const getBranches = (repoPath: string) =>
+  tauriInvoke<BranchInfo[]>('get_branches', { repoPath });
 
-export const deleteBranches = (repo_path: string, names: string[]) =>
-  tauriInvoke<DeleteResult[]>('delete_branches', { repo_path, names });
+export const deleteBranches = (repoPath: string, names: string[]) =>
+  tauriInvoke<DeleteResult[]>('delete_branches', { repoPath, names });
 
-export const fetchAll = (repo_path: string) =>
-  tauriInvoke<FetchResult>('fetch_all', { repo_path });
+export const fetchAll = (repoPath: string) =>
+  tauriInvoke<FetchResult>('fetch_all', { repoPath });
 
-export const getCommitGraph = (repo_path: string, limit?: number) =>
-  tauriInvoke<CommitNode[]>('get_commit_graph', { repo_path, limit });
+export const getCommitGraph = (repoPath: string, limit?: number) =>
+  tauriInvoke<CommitNode[]>('get_commit_graph', { repoPath, limit });
 
 // ─── GitHub PAT ──────────────────────────────────────────────────────────────
 
@@ -83,25 +86,25 @@ export const getIssues = (owner: string, repo: string, state?: string) =>
   tauriInvoke<Issue[]>('get_issues', { owner, repo, state });
 
 /** Returns check runs for the given branch name or commit SHA. */
-export const getCheckRuns = (owner: string, repo: string, git_ref: string) =>
-  tauriInvoke<CheckRun[]>('get_check_runs', { owner, repo, git_ref });
+export const getCheckRuns = (owner: string, repo: string, gitRef: string) =>
+  tauriInvoke<CheckRun[]>('get_check_runs', { owner, repo, gitRef });
 
 // ─── dsx ─────────────────────────────────────────────────────────────────────
 
 export const dsxCheck = () =>
   tauriInvoke<DsxStatus>('dsx_check');
 
-export const repoUpdate = (repo_path: string) =>
-  tauriInvoke<DsxOutput>('repo_update', { repo_path });
+export const repoUpdate = (repoPath: string) =>
+  tauriInvoke<DsxOutput>('repo_update', { repoPath });
 
-export const repoCleanupPreview = (repo_path: string) =>
-  tauriInvoke<DsxOutput>('repo_cleanup_preview', { repo_path });
+export const repoCleanupPreview = (repoPath: string) =>
+  tauriInvoke<DsxOutput>('repo_cleanup_preview', { repoPath });
 
-export const repoCleanup = (repo_path: string) =>
-  tauriInvoke<DsxOutput>('repo_cleanup', { repo_path });
+export const repoCleanup = (repoPath: string) =>
+  tauriInvoke<DsxOutput>('repo_cleanup', { repoPath });
 
-export const envInject = (repo_path: string, cmd: string) =>
-  tauriInvoke<DsxOutput>('env_inject', { repo_path, cmd });
+export const envInject = (repoPath: string, cmd: string) =>
+  tauriInvoke<DsxOutput>('env_inject', { repoPath, cmd });
 
 export const sysUpdate = () =>
   tauriInvoke<DsxOutput>('sys_update');

--- a/src/views/Cleanup.tsx
+++ b/src/views/Cleanup.tsx
@@ -26,11 +26,17 @@ export default function Cleanup() {
   const staleThreshold = 14 * 86400;
   const nowSec = Math.floor(Date.now() / 1000);
 
-  // Load branches for ALL repos.
+  // Load branches — scoped to selectedRepo if set, otherwise all repos.
   useEffect(() => {
+    const targets = selectedRepo ? repos.filter((r) => r.path === selectedRepo.path) : repos;
+    if (targets.length === 0) {
+      setMergedBranches([]);
+      setStaleBranches([]);
+      return;
+    }
     setLoading(true);
     Promise.all(
-      repos.map((r) =>
+      targets.map((r) =>
         getBranches(r.path).then((branches) =>
           branches.map((b) => ({ ...b, _repoName: r.name, _repoPath: r.path }))
         )
@@ -46,7 +52,7 @@ export default function Cleanup() {
       })
       .catch((e) => addToast(String(e), 'error'))
       .finally(() => setLoading(false));
-  }, [repos]);
+  }, [repos, selectedRepo]);
 
   const toggleSelect = (repoPath: string, name: string) =>
     setSelected((s) => {
@@ -113,9 +119,10 @@ export default function Cleanup() {
           addToast(`${selected.size} branch(es) deleted`, 'success');
         }
         setSelected(new Set());
-        // Reload branch lists.
+        // Reload branch lists (same scope as the initial load).
+        const targets = selectedRepo ? repos.filter((r) => r.path === selectedRepo.path) : repos;
         const updated = await Promise.all(
-          repos.map((r) =>
+          targets.map((r) =>
             getBranches(r.path).then((branches) =>
               branches.map((b) => ({ ...b, _repoName: r.name, _repoPath: r.path }))
             )

--- a/src/views/Cleanup.tsx
+++ b/src/views/Cleanup.tsx
@@ -6,8 +6,9 @@ import ConfirmDialog from '../components/ConfirmDialog';
 import { getBranches, repoCleanupPreview, repoCleanup, deleteBranches } from '../lib/invoke';
 import type { BranchInfo } from '../types';
 
-// Composite key: "${repoPath}:${branchName}"
-const makeKey = (repoPath: string, name: string) => `${repoPath}:${name}`;
+// Composite key: uses null byte as separator (safe on all OS — never appears in paths or branch names)
+const SEP = '\x00';
+const makeKey = (repoPath: string, name: string) => `${repoPath}${SEP}${name}`;
 
 type ConfirmType = 'dsx' | 'delete' | null;
 
@@ -70,7 +71,7 @@ export default function Cleanup() {
   };
 
   const handleDeleteSelectedWithConfirm = () => {
-    const branchNames = [...selected].map((k) => k.slice(k.indexOf(':') + 1));
+    const branchNames = [...selected].map((k) => k.slice(k.indexOf(SEP) + 1));
     setPreviewOut(branchNames.join('\n'));
     setConfirmType('delete');
   };
@@ -95,7 +96,7 @@ export default function Cleanup() {
         // Group selected branches by repo path.
         const byRepo = new Map<string, string[]>();
         for (const key of selected) {
-          const sep = key.indexOf(':');
+          const sep = key.indexOf(SEP);
           const repoPath = key.slice(0, sep);
           const branchName = key.slice(sep + 1);
           if (!byRepo.has(repoPath)) byRepo.set(repoPath, []);

--- a/src/views/PullRequests.tsx
+++ b/src/views/PullRequests.tsx
@@ -18,7 +18,8 @@ export default function PullRequests() {
   const { data: hasPat, isLoading: patLoading, isError: patError } = useQuery({
     queryKey: ['has_pat'],
     queryFn: hasGithubPat,
-    staleTime: 60_000,
+    staleTime: 0,
+    refetchOnMount: 'always',
   });
 
   const owner = selectedRepo?.github_owner ?? null;

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Settings from './Settings';
 import ToastContainer from '../components/Toast';
 import * as invoke from '../lib/invoke';
@@ -23,12 +24,13 @@ const mockConfig = {
   github_keychain_key: 'arbor_github_pat',
 };
 
-function renderWithToast() {
+function renderSettings(withToast = false) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <>
+    <QueryClientProvider client={qc}>
       <Settings />
-      <ToastContainer />
-    </>,
+      {withToast && <ToastContainer />}
+    </QueryClientProvider>,
   );
 }
 
@@ -43,7 +45,7 @@ beforeEach(() => {
 
 describe('Settings — Repositories section', () => {
   it('+ Add Repository ボタンがセクション内に表示される', async () => {
-    render(<Settings />);
+    renderSettings();
     // AppBar ではなく Repositories セクション内にボタンが存在する
     await screen.findByRole('button', { name: '+ Add Repository' });
     expect(screen.getByRole('button', { name: '+ Add Repository' })).toBeInTheDocument();
@@ -52,34 +54,34 @@ describe('Settings — Repositories section', () => {
 
 describe('Settings — dsx CLI section', () => {
   it('dsx が利用可能な場合にバージョンを表示する', async () => {
-    render(<Settings />);
+    renderSettings();
     await screen.findByText(/v0\.2\.3/);
     expect(screen.getByText(/v0\.2\.3/)).toBeInTheDocument();
   });
 
   it('dsx が利用可能な場合に Update ボタンを表示する', async () => {
-    render(<Settings />);
+    renderSettings();
     await screen.findByRole('button', { name: 'Update' });
     expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
   });
 
   it('dsx が利用不可の場合に Update ボタンを表示しない', async () => {
     mockDsxCheck.mockResolvedValue(unavailableDsxStatus as never);
-    render(<Settings />);
+    renderSettings();
     // インストール案内テキストが出るまで待つ
     await screen.findByText(/dsx が見つかりません/);
     expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
   });
 
   it('Update ボタンをクリックすると sysUpdate が呼ばれる', async () => {
-    render(<Settings />);
+    renderSettings();
     const btn = await screen.findByRole('button', { name: 'Update' });
     await userEvent.click(btn);
     expect(mockSysUpdate).toHaveBeenCalledTimes(1);
   });
 
   it('sysUpdate 完了後に dsxCheck を再呼び出しする', async () => {
-    render(<Settings />);
+    renderSettings();
     const btn = await screen.findByRole('button', { name: 'Update' });
     await userEvent.click(btn);
     await waitFor(() => {
@@ -90,7 +92,7 @@ describe('Settings — dsx CLI section', () => {
 
   it('sysUpdate が失敗した場合にエラートーストを表示する', async () => {
     mockSysUpdate.mockRejectedValue(new Error('network error') as never);
-    renderWithToast();
+    renderSettings(true);
     const btn = await screen.findByRole('button', { name: 'Update' });
     await userEvent.click(btn);
     // Toast に error メッセージが表示される（String(Error) → "Error: network error"）

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act } from 'react';
@@ -44,11 +44,15 @@ beforeEach(() => {
 });
 
 describe('Settings — Repositories section', () => {
-  it('+ Add Repository ボタンがセクション内に表示される', async () => {
+  it('+ Add Repository ボタンが AppBar ではなく Repositories セクション内に表示される', async () => {
     renderSettings();
-    // AppBar ではなく Repositories セクション内にボタンが存在する
-    await screen.findByRole('button', { name: '+ Add Repository' });
-    expect(screen.getByRole('button', { name: '+ Add Repository' })).toBeInTheDocument();
+    // REPOSITORIES 見出しを基点に親 section を取得してスコープを絞る
+    const heading = await screen.findByText('REPOSITORIES');
+    const repoSection = heading.closest('section')!;
+    expect(within(repoSection).getByRole('button', { name: '+ Add Repository' })).toBeInTheDocument();
+    // AppBar 内（section 外）には存在しないことも確認
+    const allBtns = screen.getAllByRole('button', { name: '+ Add Repository' });
+    expect(allBtns).toHaveLength(1);
   });
 });
 

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -41,6 +41,15 @@ beforeEach(() => {
   mockSysUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 } as never);
 });
 
+describe('Settings — Repositories section', () => {
+  it('+ Add Repository ボタンがセクション内に表示される', async () => {
+    render(<Settings />);
+    // AppBar ではなく Repositories セクション内にボタンが存在する
+    await screen.findByRole('button', { name: '+ Add Repository' });
+    expect(screen.getByRole('button', { name: '+ Add Repository' })).toBeInTheDocument();
+  });
+});
+
 describe('Settings — dsx CLI section', () => {
   it('dsx が利用可能な場合にバージョンを表示する', async () => {
     render(<Settings />);

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -152,7 +152,10 @@ export default function Settings() {
             Personal Access Token (PAT) を OS キーチェーンに保存します。
             PR / Issue 連携は Phase 2 で有効になります。
           </div>
-          {patStored && (
+          {patStored === null && (
+            <div style={{ fontSize: 12, color: 'var(--text3)', marginBottom: 10 }}>Checking…</div>
+          )}
+          {patStored === true && (
             <div style={{
               display: 'flex', alignItems: 'center', gap: 8,
               marginBottom: 10, fontSize: 12, color: 'var(--green)',
@@ -161,6 +164,11 @@ export default function Settings() {
               <AppBtn variant="danger" onClick={handleClearPat} disabled={patLoading}>
                 Clear
               </AppBtn>
+            </div>
+          )}
+          {patStored === false && (
+            <div style={{ fontSize: 12, color: 'var(--amber)', marginBottom: 10 }}>
+              ⚠ PAT が設定されていません
             </div>
           )}
           <div style={{ display: 'flex', gap: 8 }}>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -19,9 +19,13 @@ export default function Settings() {
   const [sysUpdating, setSysUpdating] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     getConfig().then(setConfig).catch((e) => addToast(String(e), 'error'));
     dsxCheck().then(setDsxStatus).catch(() => setDsxStatus({ available: false, version: null, path: null }));
-    hasGithubPat().then(setPatStored).catch(() => setPatStored(false));
+    hasGithubPat()
+      .then((v) => { if (!cancelled) setPatStored(v); })
+      .catch(() => { if (!cancelled) setPatStored(false); });
+    return () => { cancelled = true; };
   }, []);
 
   const handleAddRepo = async () => {

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -96,7 +96,6 @@ export default function Settings() {
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <AppBar
         path={<span style={{ color: 'var(--text2)' }}>Settings</span>}
-        actions={<AppBtn variant="primary" onClick={handleAddRepo}>+ Add Repository</AppBtn>}
       />
 
       <div style={{ flex: 1, overflowY: 'auto', padding: 24, maxWidth: 680 }}>
@@ -187,7 +186,12 @@ export default function Settings() {
 
         {/* Repositories */}
         <section style={{ marginBottom: 32 }}>
-          <SectionTitle>Repositories</SectionTitle>
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: 12 }}>
+            <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.12em', flex: 1 }}>
+              REPOSITORIES
+            </div>
+            <AppBtn variant="primary" onClick={handleAddRepo}>+ Add Repository</AppBtn>
+          </div>
           {config?.repositories.map((r) => (
             <div
               key={r.path}
@@ -209,7 +213,7 @@ export default function Settings() {
           ))}
           {config?.repositories.length === 0 && (
             <div style={{ fontSize: 12, color: 'var(--text3)' }}>
-              No repositories registered. Click "+ Add Repository" to get started.
+              No repositories registered.
             </div>
           )}
         </section>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
@@ -7,6 +8,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus } from '../types';
 
 export default function Settings() {
+  const queryClient = useQueryClient();
   const { addToast } = useUiStore();
   const { loadRepos } = useRepoStore();
   const [config, setConfig]       = useState<AppConfig | null>(null);
@@ -45,6 +47,7 @@ export default function Settings() {
       await setGithubPat(trimmed);
       setPatStored(true);
       setPatInput('');
+      queryClient.invalidateQueries({ queryKey: ['has_pat'] });
       addToast('GitHub PAT を保存しました', 'success');
     } catch (e) {
       addToast(String(e), 'error');
@@ -58,6 +61,7 @@ export default function Settings() {
     try {
       await deleteGithubPat();
       setPatStored(false);
+      queryClient.invalidateQueries({ queryKey: ['has_pat'] });
       addToast('GitHub PAT を削除しました', 'success');
     } catch (e) {
       addToast(String(e), 'error');


### PR DESCRIPTION
## Summary

- **ボタン配置**: Settings の「+ Add Repository」ボタンを AppBar → Repositories セクション内に移動
- **invoke camelCase 統一**: 複数単語 Tauri コマンド引数を camelCase に統一 (`repoPath` など)
- **Cleanup selectedRepo スコープ**: `selectedRepo` 切替時にブランチリストが対象リポジトリのみに絞り込まれるよう修正。`makeKey` のセパレータを `:` → `\x00`（Windows ドライブレター衝突回避）
- **PullRequests PAT 毎回チェック**: `has_pat` クエリに `staleTime: 0` + `refetchOnMount: 'always'` を追加し、PAT 設定後の再マウントで正しく反映されるよう修正
- **has_pat キャッシュ無効化**: Settings で PAT 保存・削除後に `invalidateQueries(['has_pat'])` を呼び出し、PullRequests 側の表示を即時更新

## Test plan

- [ ] Settings の「+ Add Repository」ボタンがリポジトリセクション内に表示される
- [ ] Cleanup でリポジトリを切り替えるとブランチリストが切り替わる
- [ ] PAT を Settings で設定後に PR/Issues 画面に切り替えると PAT 設定済みとして扱われる

🤖 Generated with [Claude Code](https://claude.com/claude-code)