### PR TITLE
feat(settings): GitHub owner/repo fields with auto-detect from git remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ src-tauri/gen/
 # Contains mutation testing data
 **/mutants.out*/
 
+# Playwright MCP server artifacts
+.playwright-mcp/
+*.png
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -43,6 +43,25 @@ pub fn remove_repository(path: String) -> Result<AppConfig, String> {
     Ok(config)
 }
 
+/// Updates the GitHub owner/repo fields for an existing registered repository.
+#[tauri::command]
+pub fn update_repository_github(
+    path: String,
+    github_owner: Option<String>,
+    github_repo: Option<String>,
+) -> Result<AppConfig, String> {
+    let mut config = load_config()?;
+    let repo = config
+        .repositories
+        .iter_mut()
+        .find(|r| r.path == path)
+        .ok_or_else(|| format!("Repository not found: {path}"))?;
+    repo.github_owner = github_owner;
+    repo.github_repo = github_repo;
+    save_config(&config)?;
+    Ok(config)
+}
+
 // ─── GitHub PAT (DPAPI encrypted → config.toml) ───────────────────────────────
 //
 // keyring v3.6.x on Windows has a bug: credentials written by one Entry instance

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -14,7 +14,7 @@ fn parse_github_url(url: &str) -> Option<(String, String)> {
         .strip_prefix("https://github.com/")
         .or_else(|| url.strip_prefix("http://github.com/"))
         .or_else(|| url.strip_prefix("git@github.com:"))?;
-    let path = path.trim_end_matches(".git");
+    let path = path.trim_end_matches('/').trim_end_matches(".git");
     let (owner, repo) = path.split_once('/')?;
     if owner.is_empty() || repo.is_empty() { return None; }
     Some((owner.to_string(), repo.to_string()))
@@ -85,20 +85,30 @@ pub fn remove_repository(path: String) -> Result<AppConfig, String> {
 }
 
 /// Updates the GitHub owner/repo fields for an existing registered repository.
+/// Both must be `Some` (non-empty) or both `None`; mixed state is rejected.
 #[tauri::command]
 pub fn update_repository_github(
     path: String,
     github_owner: Option<String>,
     github_repo: Option<String>,
 ) -> Result<AppConfig, String> {
+    // Normalise: empty strings are treated as None.
+    let owner = github_owner.and_then(|s| { let t = s.trim().to_string(); if t.is_empty() { None } else { Some(t) } });
+    let repo_name = github_repo.and_then(|s| { let t = s.trim().to_string(); if t.is_empty() { None } else { Some(t) } });
+    // Validate: both set or both None.
+    match (&owner, &repo_name) {
+        (Some(_), None) | (None, Some(_)) =>
+            return Err("github_owner と github_repo は両方設定するか、両方空にしてください".to_string()),
+        _ => {}
+    }
     let mut config = load_config()?;
     let repo = config
         .repositories
         .iter_mut()
         .find(|r| r.path == path)
         .ok_or_else(|| format!("Repository not found: {path}"))?;
-    repo.github_owner = github_owner;
-    repo.github_repo = github_repo;
+    repo.github_owner = owner;
+    repo.github_repo = repo_name;
     save_config(&config)?;
     Ok(config)
 }

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -6,6 +6,37 @@ pub fn get_config() -> Result<AppConfig, String> {
     load_config()
 }
 
+/// Parses a GitHub remote URL and returns `(owner, repo)`.
+/// Supports HTTPS (`https://github.com/owner/repo[.git]`) and
+/// SSH (`git@github.com:owner/repo[.git]`) formats.
+fn parse_github_url(url: &str) -> Option<(String, String)> {
+    let path = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))
+        .or_else(|| url.strip_prefix("git@github.com:"))?;
+    let path = path.trim_end_matches(".git");
+    let (owner, repo) = path.split_once('/')?;
+    if owner.is_empty() || repo.is_empty() { return None; }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+/// Tries to read the `origin` remote URL from the git repo and detect GitHub owner/repo.
+fn detect_from_git(repo_path: &str) -> Option<(String, String)> {
+    let repo = git2::Repository::open(repo_path).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    parse_github_url(remote.url()?)
+}
+
+/// Returns the GitHub owner and repo detected from the `origin` remote URL.
+/// Returns `null` for both fields if the remote is not a GitHub URL.
+#[tauri::command]
+pub fn detect_github_remote(path: String) -> (Option<String>, Option<String>) {
+    match detect_from_git(&path) {
+        Some((owner, repo)) => (Some(owner), Some(repo)),
+        None => (None, None),
+    }
+}
+
 #[tauri::command]
 pub fn add_repository(
     path: String,
@@ -23,6 +54,16 @@ pub fn add_repository(
     if config.repositories.iter().any(|r| r.path == path) {
         return Err(format!("Repository already registered: {path}"));
     }
+
+    // Auto-detect GitHub owner/repo from the origin remote if not provided.
+    let (github_owner, github_repo) = if github_owner.is_some() || github_repo.is_some() {
+        (github_owner, github_repo)
+    } else {
+        match detect_from_git(&path) {
+            Some((owner, repo)) => (Some(owner), Some(repo)),
+            None => (None, None),
+        }
+    };
 
     config.repositories.push(RepoConfig {
         path,
@@ -328,6 +369,32 @@ pub fn update_settings(
 
 #[cfg(test)]
 mod tests {
+    use super::parse_github_url;
+
+    #[test]
+    fn parse_github_url_https() {
+        let r = parse_github_url("https://github.com/scottlz0310/arbor.git").unwrap();
+        assert_eq!(r, ("scottlz0310".into(), "arbor".into()));
+    }
+
+    #[test]
+    fn parse_github_url_https_no_git_suffix() {
+        let r = parse_github_url("https://github.com/org/repo").unwrap();
+        assert_eq!(r, ("org".into(), "repo".into()));
+    }
+
+    #[test]
+    fn parse_github_url_ssh() {
+        let r = parse_github_url("git@github.com:scottlz0310/arbor.git").unwrap();
+        assert_eq!(r, ("scottlz0310".into(), "arbor".into()));
+    }
+
+    #[test]
+    fn parse_github_url_non_github_returns_none() {
+        assert!(parse_github_url("https://gitlab.com/org/repo.git").is_none());
+        assert!(parse_github_url("git@bitbucket.org:org/repo.git").is_none());
+    }
+
     /// キーチェーンの書き込み → 読み取り → 削除が正常に動作することを確認する。
     /// 実際の OS キーチェーンに書き込むため、デフォルトでは #[ignore] にする。
     /// `cargo test -- --ignored keyring_roundtrip` で明示的に実行すること。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,8 +4,8 @@ mod models;
 
 use commands::{
     config_cmd::{
-        add_repository, delete_github_pat, get_config, has_github_pat, remove_repository,
-        scan_directory, set_github_pat, update_repository_github, update_settings,
+        add_repository, delete_github_pat, detect_github_remote, get_config, has_github_pat,
+        remove_repository, scan_directory, set_github_pat, update_repository_github, update_settings,
     },
     dsx::{dsx_check, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
@@ -25,6 +25,7 @@ pub fn run() {
             add_repository,
             remove_repository,
             update_repository_github,
+            detect_github_remote,
             scan_directory,
             update_settings,
             // GitHub PAT

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod models;
 use commands::{
     config_cmd::{
         add_repository, delete_github_pat, get_config, has_github_pat, remove_repository,
-        scan_directory, set_github_pat, update_settings,
+        scan_directory, set_github_pat, update_repository_github, update_settings,
     },
     dsx::{dsx_check, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
@@ -24,6 +24,7 @@ pub fn run() {
             get_config,
             add_repository,
             remove_repository,
+            update_repository_github,
             scan_directory,
             update_settings,
             // GitHub PAT

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -35,6 +35,12 @@ export const addRepository = (args: {
 export const removeRepository = (path: string) =>
   tauriInvoke<AppConfig>('remove_repository', { path });
 
+export const updateRepositoryGithub = (args: {
+  path: string;
+  githubOwner: string | null;
+  githubRepo: string | null;
+}) => tauriInvoke<AppConfig>('update_repository_github', args);
+
 export const scanDirectory = (root: string) =>
   tauriInvoke<string[]>('scan_directory', { root });
 

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -41,6 +41,9 @@ export const updateRepositoryGithub = (args: {
   githubRepo: string | null;
 }) => tauriInvoke<AppConfig>('update_repository_github', args);
 
+export const detectGithubRemote = (path: string) =>
+  tauriInvoke<[string | null, string | null]>('detect_github_remote', { path });
+
 export const scanDirectory = (root: string) =>
   tauriInvoke<string[]>('scan_directory', { root });
 

--- a/src/views/Cleanup.test.tsx
+++ b/src/views/Cleanup.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import Cleanup from './Cleanup';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import * as invoke from '../lib/invoke';
+
+const mockGetBranches = vi.spyOn(invoke, 'getBranches');
+
+function makeRepo(path: string, name: string) {
+  return {
+    path,
+    name,
+    current_branch: 'main',
+    ahead: 0,
+    behind: 0,
+    modified_count: 0,
+    untracked_count: 0,
+    stash_count: 0,
+    github_owner: null,
+    github_repo: null,
+    last_fetched_at: null,
+  };
+}
+
+function makeBranch(name: string, overrides: Record<string, unknown> = {}) {
+  return {
+    name,
+    is_current: false,
+    is_merged: false,
+    is_squash_merged: false,
+    ahead: 0,
+    behind: 0,
+    last_commit_ts: Math.floor(Date.now() / 1000) - 86400 * 20, // 20 日前
+    last_commit_msg: 'test commit',
+    author: 'test',
+    remote_name: null,
+    ...overrides,
+  };
+}
+
+function renderCleanup() {
+  return render(<Cleanup />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => {
+    useRepoStore.setState({ repos: [], selectedRepo: null });
+    useUiStore.setState({ toasts: [], dsxProgress: [], dsxRunning: false });
+  });
+  mockGetBranches.mockResolvedValue([]);
+});
+
+describe('Cleanup — selectedRepo スコープ', () => {
+  const repoA = makeRepo('/repo/a', 'repo-a');
+  const repoB = makeRepo('/repo/b', 'repo-b');
+
+  it('selectedRepo が未選択の場合、全リポジトリの getBranches を呼ぶ', async () => {
+    act(() => { useRepoStore.setState({ repos: [repoA, repoB], selectedRepo: null }); });
+    renderCleanup();
+    await waitFor(() => {
+      expect(mockGetBranches).toHaveBeenCalledWith('/repo/a');
+      expect(mockGetBranches).toHaveBeenCalledWith('/repo/b');
+    });
+  });
+
+  it('selectedRepo が設定済みの場合、そのリポジトリのみ getBranches を呼ぶ', async () => {
+    act(() => { useRepoStore.setState({ repos: [repoA, repoB], selectedRepo: repoA }); });
+    renderCleanup();
+    await waitFor(() => {
+      expect(mockGetBranches).toHaveBeenCalledWith('/repo/a');
+    });
+    expect(mockGetBranches).not.toHaveBeenCalledWith('/repo/b');
+  });
+
+  it('selectedRepo 切替時に対象リポジトリのみ getBranches を呼ぶ', async () => {
+    act(() => { useRepoStore.setState({ repos: [repoA, repoB], selectedRepo: repoA }); });
+    renderCleanup();
+    await waitFor(() => expect(mockGetBranches).toHaveBeenCalledWith('/repo/a'));
+
+    // selectedRepo を repoB に切替
+    mockGetBranches.mockClear();
+    act(() => { useRepoStore.setState({ selectedRepo: repoB }); });
+    await waitFor(() => {
+      expect(mockGetBranches).toHaveBeenCalledWith('/repo/b');
+    });
+    expect(mockGetBranches).not.toHaveBeenCalledWith('/repo/a');
+  });
+});
+
+describe('Cleanup — ブランチ表示', () => {
+  const repo = makeRepo('/repo/a', 'repo-a');
+
+  it('マージ済みブランチが MERGED BRANCHES セクションに表示される', async () => {
+    mockGetBranches.mockResolvedValue([makeBranch('feature/done', { is_merged: true })]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    await screen.findByText('feature/done');
+    expect(screen.getByText('MERGED BRANCHES')).toBeInTheDocument();
+  });
+
+  it('squash マージ済みブランチも MERGED BRANCHES に表示される', async () => {
+    mockGetBranches.mockResolvedValue([makeBranch('feature/squashed', { is_squash_merged: true })]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    await screen.findByText('feature/squashed');
+    expect(screen.getByText('MERGED BRANCHES')).toBeInTheDocument();
+  });
+
+  it('古いブランチが STALE BRANCHES セクションに表示される', async () => {
+    mockGetBranches.mockResolvedValue([makeBranch('feature/old')]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    await screen.findByText('feature/old');
+    expect(screen.getByText(/STALE BRANCHES/)).toBeInTheDocument();
+  });
+
+  it('14 日以内のブランチは STALE BRANCHES に表示されない', async () => {
+    const recentBranch = makeBranch('feature/recent', {
+      last_commit_ts: Math.floor(Date.now() / 1000) - 86400 * 5, // 5 日前
+    });
+    mockGetBranches.mockResolvedValue([recentBranch]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    // セクションタイトルは表示されるが、ブランチ名は表示されない
+    await screen.findByText(/STALE BRANCHES/);
+    expect(screen.queryByText('feature/recent')).not.toBeInTheDocument();
+  });
+
+  it('現在のブランチはどのセクションにも表示されない', async () => {
+    mockGetBranches.mockResolvedValue([
+      makeBranch('main', { is_current: true, is_merged: true }),
+    ]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    // タイトルは出るが main は表示されない
+    await screen.findByText('MERGED BRANCHES');
+    expect(screen.queryByText('main')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/PullRequests.test.tsx
+++ b/src/views/PullRequests.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import PullRequests from './PullRequests';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import * as invoke from '../lib/invoke';
+
+const mockHasGithubPat = vi.spyOn(invoke, 'hasGithubPat');
+
+const baseRepo = {
+  path: '/repo/a',
+  name: 'repo-a',
+  current_branch: 'main',
+  ahead: 0,
+  behind: 0,
+  modified_count: 0,
+  untracked_count: 0,
+  stash_count: 0,
+  github_owner: null,
+  github_repo: null,
+  last_fetched_at: null,
+};
+
+function renderPullRequests() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PullRequests />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => {
+    useRepoStore.setState({ repos: [], selectedRepo: null });
+    useUiStore.setState({ activeView: 'prs', toasts: [], dsxProgress: [], dsxRunning: false });
+  });
+  mockHasGithubPat.mockResolvedValue(false as never);
+});
+
+describe('PullRequests — ガード状態', () => {
+  it('リポジトリ未選択時に選択を促すメッセージを表示する', () => {
+    renderPullRequests();
+    expect(screen.getByText('リポジトリを選択してください')).toBeInTheDocument();
+  });
+
+  it('PAT 未設定時に設定を促すメッセージを表示する', async () => {
+    act(() => { useRepoStore.setState({ selectedRepo: { ...baseRepo } }); });
+    renderPullRequests();
+    await screen.findByText('GitHub PAT が設定されていません');
+  });
+
+  it('PAT 未設定時に Settings へのナビゲーションボタンを表示する', async () => {
+    act(() => { useRepoStore.setState({ selectedRepo: { ...baseRepo } }); });
+    renderPullRequests();
+    await screen.findByRole('button', { name: 'Settings で設定する' });
+  });
+
+  it('PAT 未設定時の Settings ボタンをクリックすると settings ビューに遷移する', async () => {
+    act(() => { useRepoStore.setState({ selectedRepo: { ...baseRepo } }); });
+    renderPullRequests();
+    const btn = await screen.findByRole('button', { name: 'Settings で設定する' });
+    await userEvent.click(btn);
+    expect(useUiStore.getState().activeView).toBe('settings');
+  });
+
+  it('PAT 設定済みで owner/repo 未設定時に設定を促すメッセージを表示する', async () => {
+    mockHasGithubPat.mockResolvedValue(true as never);
+    act(() => { useRepoStore.setState({ selectedRepo: { ...baseRepo } }); });
+    renderPullRequests();
+    await screen.findByText('このリポジトリに GitHub Owner / Repo が設定されていません');
+  });
+
+  it('PAT 設定済みで owner/repo 未設定時の Settings ボタンをクリックすると settings ビューに遷移する', async () => {
+    mockHasGithubPat.mockResolvedValue(true as never);
+    act(() => { useRepoStore.setState({ selectedRepo: { ...baseRepo } }); });
+    renderPullRequests();
+    const btn = await screen.findByRole('button', { name: 'Settings で設定する' });
+    await userEvent.click(btn);
+    expect(useUiStore.getState().activeView).toBe('settings');
+  });
+
+  it('PAT 設定済みかつ owner/repo 設定済みの場合はガード画面を表示しない', async () => {
+    mockHasGithubPat.mockResolvedValue(true as never);
+    act(() => {
+      useRepoStore.setState({
+        selectedRepo: { ...baseRepo, github_owner: 'scott', github_repo: 'arbor' },
+      });
+    });
+    renderPullRequests();
+    // PR/Issues の AppBar が表示される（PRs ボタンが存在する）
+    await screen.findByRole('button', { name: 'PRs' });
+    expect(screen.queryByText('リポジトリを選択してください')).not.toBeInTheDocument();
+    expect(screen.queryByText('GitHub PAT が設定されていません')).not.toBeInTheDocument();
+    expect(screen.queryByText('このリポジトリに GitHub Owner / Repo が設定されていません')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -13,6 +13,8 @@ const mockDsxCheck = vi.spyOn(invoke, 'dsxCheck');
 const mockGetConfig = vi.spyOn(invoke, 'getConfig');
 const mockHasGithubPat = vi.spyOn(invoke, 'hasGithubPat');
 const mockSysUpdate = vi.spyOn(invoke, 'sysUpdate');
+const mockDetectGithubRemote = vi.spyOn(invoke, 'detectGithubRemote');
+const mockUpdateRepositoryGithub = vi.spyOn(invoke, 'updateRepositoryGithub');
 
 const availableDsxStatus = { available: true, version: 'v0.2.3', path: '/usr/local/bin/dsx' };
 const unavailableDsxStatus = { available: false, version: null, path: null };
@@ -22,6 +24,14 @@ const mockConfig = {
   settings: { stale_threshold_days: 30, fetch_on_startup: false },
   ai: { provider: 'ollama', model: 'qwen3.5:latest', ollama_url: 'http://localhost:11434' },
   github_keychain_key: 'arbor_github_pat',
+};
+
+const mockConfigWithRepos = {
+  repositories: [
+    { path: '/repo/arbor', name: 'arbor', github_owner: 'scott', github_repo: 'arbor-repo' },
+  ],
+  settings: { stale_threshold_days: 30, fetch_on_startup: false, github_keychain_key: 'arbor_github_pat' },
+  ai: { provider: 'ollama', model: 'qwen3.5:latest', ollama_url: 'http://localhost:11434' },
 };
 
 function renderSettings(withToast = false) {
@@ -41,6 +51,8 @@ beforeEach(() => {
   mockHasGithubPat.mockResolvedValue(false as never);
   mockDsxCheck.mockResolvedValue(availableDsxStatus as never);
   mockSysUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 } as never);
+  mockDetectGithubRemote.mockResolvedValue([null, null] as never);
+  mockUpdateRepositoryGithub.mockResolvedValue(mockConfig as never);
 });
 
 describe('Settings — Repositories section', () => {
@@ -101,5 +113,61 @@ describe('Settings — dsx CLI section', () => {
     await userEvent.click(btn);
     // Toast に error メッセージが表示される（String(Error) → "Error: network error"）
     await screen.findByText('Error: network error');
+  });
+});
+
+describe('Settings — GitHub PAT section', () => {
+  it('PAT 確認中は Checking… を表示する', async () => {
+    mockHasGithubPat.mockImplementation(() => new Promise(() => {}));
+    renderSettings();
+    // dsx セクションが読み込まれた後は PAT の Checking… のみ残る
+    await screen.findByText(/v0\.2\.3/);
+    expect(screen.getByText('Checking…')).toBeInTheDocument();
+  });
+
+  it('PAT 未設定時に警告テキストを表示する', async () => {
+    renderSettings();
+    await screen.findByText(/PAT が設定されていません/);
+  });
+
+  it('PAT 設定済み時に保存済みテキストと Clear ボタンを表示する', async () => {
+    mockHasGithubPat.mockResolvedValue(true as never);
+    renderSettings();
+    await screen.findByText(/PAT が保存されています/);
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
+  });
+});
+
+describe('Settings — RepoCard', () => {
+  it('登録済みリポジトリの owner と repo が入力欄に表示される', async () => {
+    mockGetConfig.mockResolvedValue(mockConfigWithRepos as never);
+    renderSettings();
+    expect(await screen.findByDisplayValue('scott')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('arbor-repo')).toBeInTheDocument();
+  });
+
+  it('owner と repo が変更されていない時は RepoCard の Save ボタンが disabled', async () => {
+    mockGetConfig.mockResolvedValue(mockConfigWithRepos as never);
+    renderSettings();
+    await screen.findByDisplayValue('scott');
+    // PAT Save と RepoCard Save の 2 つが存在するため getAllByRole で取得
+    const saveBtns = screen.getAllByRole('button', { name: 'Save' });
+    // どちらも disabled（PAT 入力欄は空、RepoCard は未変更）
+    saveBtns.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('Detect ボタンが表示される', async () => {
+    mockGetConfig.mockResolvedValue(mockConfigWithRepos as never);
+    renderSettings();
+    await screen.findByRole('button', { name: 'Detect' });
+  });
+
+  it('Detect ボタンをクリックすると detectGithubRemote がリポジトリのパスで呼ばれる', async () => {
+    mockGetConfig.mockResolvedValue(mockConfigWithRepos as never);
+    mockDetectGithubRemote.mockResolvedValue(['scott', 'arbor-repo'] as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'Detect' });
+    await userEvent.click(btn);
+    expect(mockDetectGithubRemote).toHaveBeenCalledWith('/repo/arbor');
   });
 });

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, updateRepositoryGithub, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus, RepoConfig } from '../types';
 
@@ -251,11 +251,12 @@ function RepoCard({
 }: {
   repo: RepoConfig;
   onRemove: (path: string) => void;
-  onSaveGithub: (path: string, owner: string, repo: string) => Promise<void>;
+  onSaveGithub: (path: string, owner: string, repoName: string) => Promise<void>;
 }) {
   const [owner, setOwner] = useState(repo.github_owner ?? '');
   const [repoName, setRepoName] = useState(repo.github_repo ?? '');
   const [saving, setSaving] = useState(false);
+  const [detecting, setDetecting] = useState(false);
 
   const dirty = owner !== (repo.github_owner ?? '') || repoName !== (repo.github_repo ?? '');
 
@@ -263,6 +264,17 @@ function RepoCard({
     setSaving(true);
     try { await onSaveGithub(repo.path, owner, repoName); }
     finally { setSaving(false); }
+  };
+
+  const handleDetect = async () => {
+    setDetecting(true);
+    try {
+      const [detectedOwner, detectedRepo] = await detectGithubRemote(repo.path);
+      if (detectedOwner) setOwner(detectedOwner);
+      if (detectedRepo) setRepoName(detectedRepo);
+    } finally {
+      setDetecting(false);
+    }
   };
 
   const inputStyle: React.CSSProperties = {
@@ -283,6 +295,9 @@ function RepoCard({
           <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text1)' }}>{repo.name}</div>
           <div style={{ fontSize: 10, color: 'var(--text3)', fontFamily: 'var(--font-mono)' }}>{repo.path}</div>
         </div>
+        <AppBtn onClick={handleDetect} disabled={detecting}>
+          {detecting ? '…' : 'Detect'}
+        </AppBtn>
         <AppBtn variant="danger" onClick={() => onRemove(repo.path)}>Remove</AppBtn>
       </div>
       <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -3,9 +3,9 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, updateRepositoryGithub, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
-import type { AppConfig, DsxStatus } from '../types';
+import type { AppConfig, DsxStatus, RepoConfig } from '../types';
 
 export default function Settings() {
   const queryClient = useQueryClient();
@@ -208,23 +208,18 @@ export default function Settings() {
             <AppBtn variant="primary" onClick={handleAddRepo}>+ Add Repository</AppBtn>
           </div>
           {config?.repositories.map((r) => (
-            <div
+            <RepoCard
               key={r.path}
-              style={{
-                display: 'flex', alignItems: 'center', gap: 12,
-                padding: '10px 14px', background: 'var(--bg3)',
-                border: '1px solid var(--border)', borderRadius: 'var(--r)',
-                marginBottom: 6,
+              repo={r}
+              onRemove={handleRemoveRepo}
+              onSaveGithub={async (path, owner, repo) => {
+                try {
+                  const updated = await updateRepositoryGithub({ path, githubOwner: owner || null, githubRepo: repo || null });
+                  setConfig(updated);
+                  addToast('GitHub 設定を保存しました', 'success');
+                } catch (e) { addToast(String(e), 'error'); }
               }}
-            >
-              <div style={{ flex: 1 }}>
-                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text1)' }}>{r.name}</div>
-                <div style={{ fontSize: 10, color: 'var(--text3)', fontFamily: 'var(--font-mono)' }}>
-                  {r.path}
-                </div>
-              </div>
-              <AppBtn variant="danger" onClick={() => handleRemoveRepo(r.path)}>Remove</AppBtn>
-            </div>
+            />
           ))}
           {config?.repositories.length === 0 && (
             <div style={{ fontSize: 12, color: 'var(--text3)' }}>
@@ -244,6 +239,71 @@ export default function Settings() {
           </div>
         </section>
 
+      </div>
+    </div>
+  );
+}
+
+function RepoCard({
+  repo,
+  onRemove,
+  onSaveGithub,
+}: {
+  repo: RepoConfig;
+  onRemove: (path: string) => void;
+  onSaveGithub: (path: string, owner: string, repo: string) => Promise<void>;
+}) {
+  const [owner, setOwner] = useState(repo.github_owner ?? '');
+  const [repoName, setRepoName] = useState(repo.github_repo ?? '');
+  const [saving, setSaving] = useState(false);
+
+  const dirty = owner !== (repo.github_owner ?? '') || repoName !== (repo.github_repo ?? '');
+
+  const handleSave = async () => {
+    setSaving(true);
+    try { await onSaveGithub(repo.path, owner, repoName); }
+    finally { setSaving(false); }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    background: 'var(--bg2)', border: '1px solid var(--border)',
+    borderRadius: 'var(--r)', color: 'var(--text1)',
+    fontSize: 11, fontFamily: 'var(--font-mono)',
+    padding: '4px 8px', outline: 'none', width: '100%',
+  };
+
+  return (
+    <div style={{
+      padding: '10px 14px', background: 'var(--bg3)',
+      border: '1px solid var(--border)', borderRadius: 'var(--r)',
+      marginBottom: 6,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text1)' }}>{repo.name}</div>
+          <div style={{ fontSize: 10, color: 'var(--text3)', fontFamily: 'var(--font-mono)' }}>{repo.path}</div>
+        </div>
+        <AppBtn variant="danger" onClick={() => onRemove(repo.path)}>Remove</AppBtn>
+      </div>
+      <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+        <input
+          style={inputStyle}
+          placeholder="owner"
+          value={owner}
+          onChange={(e) => setOwner(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && dirty && handleSave()}
+        />
+        <span style={{ color: 'var(--text3)', fontSize: 12 }}>/</span>
+        <input
+          style={inputStyle}
+          placeholder="repo"
+          value={repoName}
+          onChange={(e) => setRepoName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && dirty && handleSave()}
+        />
+        <AppBtn variant="primary" onClick={handleSave} disabled={!dirty || saving}>
+          {saving ? '…' : 'Save'}
+        </AppBtn>
       </div>
     </div>
   );

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -216,6 +216,7 @@ export default function Settings() {
                 try {
                   const updated = await updateRepositoryGithub({ path, githubOwner: owner || null, githubRepo: repo || null });
                   setConfig(updated);
+                  await loadRepos();
                   addToast('GitHub 設定を保存しました', 'success');
                 } catch (e) { addToast(String(e), 'error'); }
               }}
@@ -253,16 +254,22 @@ function RepoCard({
   onRemove: (path: string) => void;
   onSaveGithub: (path: string, owner: string, repoName: string) => Promise<void>;
 }) {
+  const { addToast } = useUiStore();
   const [owner, setOwner] = useState(repo.github_owner ?? '');
   const [repoName, setRepoName] = useState(repo.github_repo ?? '');
   const [saving, setSaving] = useState(false);
   const [detecting, setDetecting] = useState(false);
 
-  const dirty = owner !== (repo.github_owner ?? '') || repoName !== (repo.github_repo ?? '');
+  const ownerTrimmed = owner.trim();
+  const repoTrimmed = repoName.trim();
+  const dirty = ownerTrimmed !== (repo.github_owner ?? '') || repoTrimmed !== (repo.github_repo ?? '');
+  const bothSet = ownerTrimmed !== '' && repoTrimmed !== '';
+  const bothEmpty = ownerTrimmed === '' && repoTrimmed === '';
+  const validCombo = bothSet || bothEmpty;
 
   const handleSave = async () => {
     setSaving(true);
-    try { await onSaveGithub(repo.path, owner, repoName); }
+    try { await onSaveGithub(repo.path, ownerTrimmed, repoTrimmed); }
     finally { setSaving(false); }
   };
 
@@ -272,6 +279,8 @@ function RepoCard({
       const [detectedOwner, detectedRepo] = await detectGithubRemote(repo.path);
       if (detectedOwner) setOwner(detectedOwner);
       if (detectedRepo) setRepoName(detectedRepo);
+    } catch (e) {
+      addToast(String(e), 'error');
     } finally {
       setDetecting(false);
     }
@@ -316,10 +325,15 @@ function RepoCard({
           onChange={(e) => setRepoName(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && dirty && handleSave()}
         />
-        <AppBtn variant="primary" onClick={handleSave} disabled={!dirty || saving}>
+        <AppBtn variant="primary" onClick={handleSave} disabled={!dirty || saving || !validCombo}>
           {saving ? '…' : 'Save'}
         </AppBtn>
       </div>
+      {!validCombo && (
+        <div style={{ fontSize: 10, color: 'var(--amber)', marginTop: 4 }}>
+          owner と repo は両方設定するか、両方空にしてください
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **RepoCard**: Settings のリポジトリ一覧に `owner` / `repo` インライン入力 + Save ボタンを追加
- **Detect ボタン**: git2 で `origin` remote URL を読み取り、HTTPS / SSH 両形式から `owner/repo` を自動検出
- **add_repository 自動設定**: リポジトリ追加時に自動で `origin` remote を解析し `github_owner` / `github_repo` を設定
- **`update_repository_github` コマンド**: 既存リポジトリの owner/repo を更新する Tauri コマンドを追加
- **`detect_github_remote` コマンド**: フロントからパスを受け取り `(Option<String>, Option<String>)` を返す Tauri コマンド
- **回帰テスト追加**: `Settings.test.tsx`（PAT 三値表示・RepoCard）、`Cleanup.test.tsx`（selectedRepo スコープ）、`PullRequests.test.tsx`（ガード状態）新規追加（計 57 テスト）

> **ベース**: `fix/pr2-pat-dpapi` — PR #29 がマージされたら base を更新してください

## Test plan

- [ ] Settings → リポジトリの Detect を押すと owner/repo が自動入力される
- [ ] owner/repo を変更すると Save ボタンが有効になる
- [ ] 保存後に PR/Issues 画面で「GitHub Owner / Repo が設定されていません」が消える
- [ ] `npm test` (57 件) すべて合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)