### PR TITLE
docs(claude): update dev commands from cargo tauri to pnpm tauri

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ pnpm tauri build        # リリースビルド (.msi / .dmg)
 
 ### Rust チェック
 ```bash
-# src-tauri/ に cd せずプロジェクトルートから実行可能
-cargo check             # コンパイルチェック（ビルドなし、高速）
-cargo clippy            # Lint
-cargo test              # テスト実行
+# Cargo.toml は src-tauri/ 配下のため --manifest-path を指定する
+cargo check  --manifest-path src-tauri/Cargo.toml   # コンパイルチェック（ビルドなし、高速）
+cargo clippy --manifest-path src-tauri/Cargo.toml   # Lint
+cargo test   --manifest-path src-tauri/Cargo.toml   # テスト実行
 ```
 
 ### フロントエンドのみ

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,13 @@ dsx --version           # dsx CLI v0.2.2+ が PATH に必要
 ### 起動・ビルド
 ```bash
 pnpm install            # フロントエンド依存インストール
-cargo tauri dev         # 開発サーバー起動 (Vite + Tauri ホットリロード)
-cargo tauri build       # リリースビルド (.msi / .dmg)
+pnpm tauri dev          # 開発サーバー起動 (Vite + Tauri ホットリロード)
+pnpm tauri build        # リリースビルド (.msi / .dmg)
 ```
 
 ### Rust チェック
 ```bash
-cd src-tauri
+# src-tauri/ に cd せずプロジェクトルートから実行可能
 cargo check             # コンパイルチェック（ビルドなし、高速）
 cargo clippy            # Lint
 cargo test              # テスト実行


### PR DESCRIPTION
## Summary

- `cargo tauri dev` / `cargo tauri build` → `pnpm tauri dev` / `pnpm tauri build` に修正
- Rust チェックコマンドのコメントを「`src-tauri/` に cd せずプロジェクトルートから実行可能」に明確化

## 背景

pnpm 移行（PR #31）後、`cargo tauri` サブコマンドは PATH に存在せず `cargo tauri dev` が失敗する。
pnpm 経由で呼ぶのが正しい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)