### PR TITLE
feat: Settings にリポジトリ一括スキャン UI を追加し Sidebar スクロールを修正

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,8 +47,14 @@ export default function Sidebar() {
         </div>
       </div>
 
-      {/* Repository list */}
-      <div style={{ padding: '8px', borderBottom: '1px solid var(--border)' }}>
+      {/* Repository list — flex:1 + overflow-y:auto でスクロール可能にする (#44) */}
+      <div style={{
+        padding: '8px',
+        borderBottom: '1px solid var(--border)',
+        flex: 1,
+        minHeight: 0,
+        overflowY: 'auto',
+      }}>
         {repos.map((repo) => (
           <button
             key={repo.path}
@@ -105,8 +111,8 @@ export default function Sidebar() {
         ))}
       </div>
 
-      {/* Navigation */}
-      <nav style={{ padding: '8px', flex: 1 }}>
+      {/* Navigation — 固定高さ（flex:1 は repo list 側に移動） */}
+      <nav style={{ padding: '8px' }}>
         {NAV_ITEMS.map((item) => (
           <button
             key={item.id}

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -73,11 +73,11 @@ export default function Settings() {
     if (!scanResults) return;
     const targets = scanResults.filter((p) => scanSelected.has(p));
     let added = 0;
+    let lastConfig: AppConfig | null = null;
     for (const path of targets) {
       const name = path.split(/[\\/]/).pop() ?? path;
       try {
-        const updated = await addRepository({ path, name });
-        setConfig(updated);
+        lastConfig = await addRepository({ path, name });
         added++;
       } catch (e) {
         // already registered は skip、その他はトーストへ
@@ -87,6 +87,7 @@ export default function Settings() {
       }
     }
     if (added > 0) {
+      if (lastConfig) setConfig(lastConfig);
       await loadRepos();
       addToast(`${added} 件のリポジトリを追加しました`, 'success');
     }
@@ -305,7 +306,7 @@ export default function Settings() {
                         }}
                       />
                       <span style={{ color: 'var(--text1)', fontWeight: 600 }}>{name}</span>
-                      <span style={{ color: 'var(--text3)', fontFamily: 'var(--font-mono)', fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <span style={{ flex: 1, minWidth: 0, color: 'var(--text3)', fontFamily: 'var(--font-mono)', fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {p}
                       </span>
                     </label>

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus, RepoConfig } from '../types';
 
@@ -17,6 +17,9 @@ export default function Settings() {
   const [patInput, setPatInput]   = useState('');
   const [patLoading, setPatLoading] = useState(false);
   const [sysUpdating, setSysUpdating] = useState(false);
+  const [scanResults, setScanResults] = useState<string[] | null>(null);
+  const [scanSelected, setScanSelected] = useState<Set<string>>(new Set());
+  const [scanning, setScanning] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -41,6 +44,54 @@ export default function Settings() {
     } catch (e) {
       addToast(String(e), 'error');
     }
+  };
+
+  const handleScanAndAdd = async () => {
+    const selected = await open({ directory: true, multiple: false, title: 'スキャンするフォルダを選択' });
+    if (!selected) return;
+    const root = typeof selected === 'string' ? selected : selected[0];
+    setScanning(true);
+    try {
+      const found = await scanDirectory(root);
+      // 既登録パスを除外する
+      const registered = new Set(config?.repositories.map((r) => r.path) ?? []);
+      const newPaths = found.filter((p) => !registered.has(p));
+      if (newPaths.length === 0) {
+        addToast('新しいリポジトリは見つかりませんでした', 'success');
+        return;
+      }
+      setScanResults(newPaths);
+      setScanSelected(new Set(newPaths));
+    } catch (e) {
+      addToast(String(e), 'error');
+    } finally {
+      setScanning(false);
+    }
+  };
+
+  const handleBulkRegister = async () => {
+    if (!scanResults) return;
+    const targets = scanResults.filter((p) => scanSelected.has(p));
+    let added = 0;
+    for (const path of targets) {
+      const name = path.split(/[\\/]/).pop() ?? path;
+      try {
+        const updated = await addRepository({ path, name });
+        setConfig(updated);
+        added++;
+      } catch (e) {
+        // already registered は skip、その他はトーストへ
+        if (!String(e).includes('already registered')) {
+          addToast(`${name}: ${String(e)}`, 'error');
+        }
+      }
+    }
+    if (added > 0) {
+      await loadRepos();
+      addToast(`${added} 件のリポジトリを追加しました`, 'success');
+    }
+    setScanResults(null);
+    setScanSelected(new Set());
   };
 
   const handleSavePat = async () => {
@@ -205,8 +256,76 @@ export default function Settings() {
             <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.12em', flex: 1 }}>
               REPOSITORIES
             </div>
+            <AppBtn onClick={handleScanAndAdd} disabled={scanning} style={{ marginRight: 6 }}>
+              {scanning ? 'Scanning…' : '⊕ Scan Folder'}
+            </AppBtn>
             <AppBtn variant="primary" onClick={handleAddRepo}>+ Add Repository</AppBtn>
           </div>
+
+          {/* スキャン結果確認 UI (#43) */}
+          {scanResults && (
+            <div style={{
+              background: 'var(--bg3)',
+              border: '1px solid var(--border2)',
+              borderRadius: 'var(--r2)',
+              padding: '14px 16px',
+              marginBottom: 12,
+            }}>
+              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text1)', marginBottom: 4 }}>
+                {scanResults.length} 件のリポジトリが見つかりました
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--text3)', marginBottom: 10 }}>
+                ※ 最大 4 階層まで探索。登録するリポジトリを選択してください。
+              </div>
+              <div style={{ maxHeight: 200, overflowY: 'auto', marginBottom: 10 }}>
+                {scanResults.map((p) => {
+                  const name = p.split(/[\\/]/).pop() ?? p;
+                  const checked = scanSelected.has(p);
+                  return (
+                    <label
+                      key={p}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        padding: '4px 2px',
+                        cursor: 'pointer',
+                        fontSize: 12,
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => {
+                          setScanSelected((prev) => {
+                            const next = new Set(prev);
+                            checked ? next.delete(p) : next.add(p);
+                            return next;
+                          });
+                        }}
+                      />
+                      <span style={{ color: 'var(--text1)', fontWeight: 600 }}>{name}</span>
+                      <span style={{ color: 'var(--text3)', fontFamily: 'var(--font-mono)', fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {p}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+                <AppBtn onClick={() => { setScanResults(null); setScanSelected(new Set()); }}>
+                  Cancel
+                </AppBtn>
+                <AppBtn
+                  variant="primary"
+                  onClick={handleBulkRegister}
+                  disabled={scanSelected.size === 0}
+                >
+                  {scanSelected.size} 件を追加
+                </AppBtn>
+              </div>
+            </div>
+          )}
           {config?.repositories.map((r) => (
             <RepoCard
               key={r.path}


### PR DESCRIPTION
## Summary

- **#43 — Settings 一括スキャン**: `⊕ Scan Folder` ボタンから `scan_directory` を呼び出し、チェックボックス形式の確認 UI でリポジトリを選択して一括登録できるようにした
  - 既登録パスはスキャン結果から自動除外
  - `name` はパス末尾セグメントから自動生成
  - 深さ制限（最大 4 階層）を UI に明示
  - 重複エラーは silent skip、その他のエラーは Toast 表示
- **#44 — Sidebar スクロール**: リポジトリリスト div に `flex: 1 / overflow-y: auto / min-height: 0` を追加、`<nav>` の `flex: 1` を削除することで、リポジトリ数が多い場合でも Sidebar 内でスクロール可能にした
  - Overview のスクロールコンテナは既に `overflowY: auto` を持っているため変更なし

## Changed files

| ファイル | 変更内容 |
|---------|---------|
| `src/views/Settings.tsx` | `scanDirectory` import 追加、`handleScanAndAdd` / `handleBulkRegister` ハンドラ実装、スキャン結果確認 UI 追加 |
| `src/components/Sidebar.tsx` | リポジトリリストに scroll 用スタイル追加、nav から `flex: 1` 削除 |

## Test plan

- [x] Settings > `⊕ Scan Folder` → フォルダ選択ダイアログが開く
- [x] スキャン結果が checkbox 付きリストで表示される（既登録リポジトリは含まれない）
- [x] 一部チェックを外して「N 件を追加」→ 選択分だけ登録され Toast が出る
- [x] 新しいリポジトリがない場合「見つかりませんでした」Toast が出る
- [x] リポジトリ数が多い場合に Sidebar がスクロールできる
- [x] ナビゲーション 6 件が画面下部に固定表示される（`flex: 1` 除去の確認）

Closes #43
Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)