### PR TITLE
chore(renovate): suppress major updates of keyring crate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,14 @@
     "github>scottlz0310/renovate-config//presets/options/automerge",
     "github>scottlz0310/renovate-config//presets/options/schedule",
     "github>scottlz0310/renovate-config//presets/options/security"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["keyring"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+      "description": "keyring v4 はライブラリではなくサンプルアプリ化された。credential store API は keyring-core へ分離されたため major update は適用しない（移行は別 ISSUE 管理）"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- `renovate.json` に packageRule を追加し、`keyring` クレートの major update を Renovate が自動 PR 化しないよう抑止する
- 背景: [keyring v4.0.0](https://github.com/open-source-cooperative/keyring-rs/releases/tag/v4.0.0) はライブラリではなくサンプルアプリ化され、credential store API（`Entry` 等）は [`keyring-core`](https://crates.io/crates/keyring-core) v1.0 に分離された。Arbor は `keyring::Entry` を直接使用しているため単純な major update は不可能で、#70 でも CI が失敗した
- `keyring-core` への移行作業は #73 で別途管理する

## Test plan

- [ ] Renovate のドライラン or 次回スケジュールで keyring の major update PR が再作成されないことを確認
- [ ] `renovate.json` の JSON が valid であること（CI で検証されることを期待）

## Related

- Closes #70 （クローズ済みの Renovate PR）
- Refs #73 （keyring-core 移行 ISSUE）

🤖 Generated with [Claude Code](https://claude.com/claude-code)