### PR TITLE
refactor(deps): migrate from keyring v3 to keyring-core v1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,12 +59,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "arbor"
 version = "0.1.0"
 dependencies = [
+ "apple-native-keyring-store",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "git2",
- "keyring",
+ "keyring-core",
  "reqwest",
  "serde",
  "serde_json",
@@ -169,6 +193,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -298,6 +331,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +400,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -590,6 +642,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +721,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1405,6 +1486,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1807,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,13 +1961,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
- "zeroize",
 ]
 
 [[package]]
@@ -2152,10 +2260,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -5709,6 +5881,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,6 @@ toml           = "1.1.2"
 git2           = "0.20.4"
 tokio          = { version = "1.52.1", features = ["full"] }
 reqwest        = { version = "0.13.3", features = ["json"] }
-keyring        = "3.6.3"
 dirs           = "6.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -27,3 +26,13 @@ windows-sys    = { version = "0.61.2", features = [
     "Win32_Security_Cryptography",
     "Win32_System_Memory",
 ] }
+
+# Windows では DPAPI を使用するため keyring 系は不要。
+# macOS/Linux のみ keyring-core + platform-native credential store を依存。
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring-core   = "1.0"
+apple-native-keyring-store = { version = "1.0", features = ["keychain"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring-core   = "1.0"
+dbus-secret-service-keyring-store = { version = "1.0", features = ["crypto-rust"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,10 +29,11 @@ windows-sys    = { version = "0.61.2", features = [
 
 # Windows では DPAPI を使用するため keyring 系は不要。
 # macOS/Linux のみ keyring-core + platform-native credential store を依存。
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 keyring-core   = "1.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store = { version = "1.0", features = ["keychain"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-keyring-core   = "1.0"
 dbus-secret-service-keyring-store = { version = "1.0", features = ["crypto-rust"] }

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -215,37 +215,44 @@ mod pat_crypto {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 mod pat_crypto {
-    use std::sync::Once;
+    use std::sync::Mutex;
 
     // Keep the same service/user pair as used before this PR for backward compatibility.
     const SERVICE: &str = "arbor_github_pat";
     const USER: &str = "github";
 
-    static INIT_STORE: Once = Once::new();
+    /// `false` until the default credential store has been successfully registered.
+    /// Initialization failures do not flip this flag, so subsequent calls retry
+    /// (`Once::call_once` would have permanently locked us out after a transient failure).
+    static INIT_STORE: Mutex<bool> = Mutex::new(false);
 
-    /// keyring-core requires a default credential store to be registered once
-    /// per process before any Entry can be created.
-    /// Store::new() returns Result<Arc<Self>>, which is unsized to Arc<dyn CredentialStore>
-    /// when passed to keyring_core::set_default_store.
-    pub(super) fn ensure_default_store() {
-        INIT_STORE.call_once(|| {
-            #[cfg(target_os = "macos")]
-            match apple_native_keyring_store::keychain::Store::new() {
-                Ok(s) => keyring_core::set_default_store(s),
-                Err(e) => eprintln!("credential store の初期化に失敗: {e}"),
-            }
-            #[cfg(target_os = "linux")]
-            match dbus_secret_service_keyring_store::Store::new() {
-                Ok(s) => keyring_core::set_default_store(s),
-                Err(e) => eprintln!("credential store の初期化に失敗: {e}"),
-            }
-        });
+    /// Registers a platform-native credential store as keyring-core's default,
+    /// at most once per process. Failures propagate so the caller can surface
+    /// them and retry on the next invocation.
+    pub(super) fn ensure_default_store() -> Result<(), String> {
+        let mut initialized = INIT_STORE
+            .lock()
+            .map_err(|e| format!("credential store 初期化ロックの取得に失敗: {e}"))?;
+        if *initialized {
+            return Ok(());
+        }
+
+        #[cfg(target_os = "macos")]
+        let store = apple_native_keyring_store::keychain::Store::new()
+            .map_err(|e| format!("credential store の初期化に失敗: {e}"))?;
+        #[cfg(target_os = "linux")]
+        let store = dbus_secret_service_keyring_store::Store::new()
+            .map_err(|e| format!("credential store の初期化に失敗: {e}"))?;
+
+        keyring_core::set_default_store(store);
+        *initialized = true;
+        Ok(())
     }
 
     fn keychain_entry() -> Result<keyring_core::Entry, String> {
-        ensure_default_store();
+        ensure_default_store()?;
         keyring_core::Entry::new(SERVICE, USER)
             .map_err(|e| format!("keychain エラー: {e}"))
     }
@@ -294,10 +301,10 @@ pub(crate) fn load_github_pat() -> Result<String, String> {
     match &config.settings.github_pat_enc {
         Some(blob) => pat_decrypt(blob),
         None => {
-            // Non-Windows: fall back to keyring for pre-migration PATs (github_pat_enc absent).
-            #[cfg(not(target_os = "windows"))]
+            // macOS/Linux: fall back to keyring for pre-migration PATs (github_pat_enc absent).
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             return pat_crypto::decrypt("");
-            #[cfg(target_os = "windows")]
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
             Err("GitHub PAT が設定されていません。Settings から PAT を登録してください。".to_string())
         }
     }
@@ -319,7 +326,7 @@ pub fn set_github_pat(pat: String) -> Result<(), String> {
 
 /// Returns true if a GitHub PAT is stored, false if not.
 /// The PAT value is never exposed over IPC; retrieval is internal to Rust commands.
-/// On non-Windows: also checks keyring directly for pre-migration installs where
+/// On macOS/Linux: also checks keyring directly for pre-migration installs where
 /// `github_pat_enc` is None.
 #[tauri::command]
 pub fn has_github_pat() -> Result<bool, String> {
@@ -327,21 +334,21 @@ pub fn has_github_pat() -> Result<bool, String> {
     if config.settings.github_pat_enc.is_some() {
         return Ok(true);
     }
-    // Non-Windows: fall back to keyring for pre-migration PATs.
-    #[cfg(not(target_os = "windows"))]
+    // macOS/Linux: fall back to keyring for pre-migration PATs.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     return Ok(pat_crypto::has_in_keyring());
-    #[cfg(target_os = "windows")]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     Ok(false)
 }
 
 /// Removes the GitHub PAT from config.toml.
-/// On non-Windows: also deletes the keyring entry.
+/// On macOS/Linux: also deletes the keyring entry.
 #[tauri::command]
 pub fn delete_github_pat() -> Result<(), String> {
     let mut config = load_config()?;
     config.settings.github_pat_enc = None;
     save_config(&config)?;
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     pat_crypto::delete()?;
     Ok(())
 }
@@ -431,7 +438,7 @@ mod tests {
     /// キーチェーンの書き込み → 読み取り → 削除が正常に動作することを確認する。
     /// 実際の OS キーチェーンに書き込むため、デフォルトでは #[ignore] にする。
     /// `cargo test -- --ignored keyring_roundtrip` で明示的に実行すること。
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     #[ignore = "実 OS キーチェーンへのアクセスが必要。cargo test -- --ignored で実行"]
     fn keyring_roundtrip() {
@@ -439,7 +446,10 @@ mod tests {
         const USER: &str = "test";
         const SECRET: &str = "roundtrip_secret_12345";
 
-        super::pat_crypto::ensure_default_store();
+        if let Err(e) = super::pat_crypto::ensure_default_store() {
+            eprintln!("ensure_default_store failed ({e}) — skipping");
+            return;
+        }
 
         let entry = match keyring_core::Entry::new(SERVICE, USER) {
             Ok(e) => e,
@@ -472,8 +482,8 @@ mod tests {
     /// 別の Entry インスタンスで書き込まれた値を読み取れるか確認する。
     /// keyring v3.6.x on Windows では cross-entry read が NoEntry を返す既知のバグがあったため、
     /// Windows では DPAPI フォールバックを採用してきた。Windows ではそもそも keyring-core 依存を
-    /// 持たないため、このテストは non-Windows でのみコンパイル対象とする。
-    #[cfg(not(target_os = "windows"))]
+    /// 持たないため、このテストは macOS/Linux でのみコンパイル対象とする。
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     #[ignore = "実 OS キーチェーンへのアクセスが必要。cargo test -- --ignored で実行"]
     fn keyring_cross_entry_roundtrip() {
@@ -481,7 +491,10 @@ mod tests {
         const USER: &str = "arbor";
         const SECRET: &str = "cross_entry_secret_12345";
 
-        super::pat_crypto::ensure_default_store();
+        if let Err(e) = super::pat_crypto::ensure_default_store() {
+            eprintln!("ensure_default_store failed ({e}) — skipping");
+            return;
+        }
 
         // Clean up any leftover from a previous run.
         if let Ok(e) = keyring_core::Entry::new(SERVICE, USER) { let _ = e.delete_credential(); }

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -122,6 +122,14 @@ pub fn update_repository_github(
 //
 // macOS/Linux: use keyring-core v1 with a platform-native credential store
 // (Apple Keychain on macOS, Secret Service via D-Bus on Linux).
+//
+// Other platforms are unsupported — Arbor (Tauri) only ships for these three OS.
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+compile_error!(
+    "Arbor は Windows / macOS / Linux のみをサポートしています。\n\
+     PAT ストレージ実装が未提供のターゲットです。"
+);
 
 #[cfg(target_os = "windows")]
 mod pat_crypto {
@@ -254,7 +262,7 @@ mod pat_crypto {
     fn keychain_entry() -> Result<keyring_core::Entry, String> {
         ensure_default_store()?;
         keyring_core::Entry::new(SERVICE, USER)
-            .map_err(|e| format!("keychain エラー: {e}"))
+            .map_err(|e| format!("credential store エラー: {e}"))
     }
 
     pub fn encrypt(plaintext: &str) -> Result<String, String> {

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -271,12 +271,23 @@ mod pat_crypto {
     }
 
     pub fn decrypt(_encoded: &str) -> Result<String, String> {
-        keychain_entry()?.get_password().map_err(|e| format!("{e}"))
+        keychain_entry()?.get_password().map_err(|e| match e {
+            keyring_core::Error::NoEntry => {
+                "GitHub PAT が設定されていません。Settings から PAT を登録してください。".to_string()
+            }
+            other => format!("{other}"),
+        })
     }
 
-    /// Returns true if a PAT entry exists in the keyring.
-    pub fn has_in_keyring() -> bool {
-        keychain_entry().map(|e| e.get_password().is_ok()).unwrap_or(false)
+    /// Returns `Ok(true)` if a PAT entry exists in the keyring, `Ok(false)` if not,
+    /// and `Err` if the credential store could not be initialised or queried.
+    /// Returning a Result lets callers distinguish "no PAT" from "store unavailable".
+    pub fn has_in_keyring() -> Result<bool, String> {
+        match keychain_entry()?.get_password() {
+            Ok(_) => Ok(true),
+            Err(keyring_core::Error::NoEntry) => Ok(false),
+            Err(e) => Err(format!("{e}")),
+        }
     }
 
     /// Removes the keyring entry. `NoEntry` is treated as success.
@@ -302,7 +313,7 @@ fn pat_decrypt(encoded: &str) -> Result<String, String> {
 /// Internal helper used by GitHub API commands to retrieve the stored PAT.
 /// Not a Tauri command — the secret stays inside the Rust process.
 /// On Windows: decrypts the DPAPI blob from `github_pat_enc`.
-/// On non-Windows: reads from OS keyring (falls back to keyring directly when
+/// On macOS/Linux: reads from OS keyring (falls back to keyring directly when
 /// `github_pat_enc` is None, supporting pre-migration installs).
 pub(crate) fn load_github_pat() -> Result<String, String> {
     let config = load_config()?;
@@ -320,7 +331,7 @@ pub(crate) fn load_github_pat() -> Result<String, String> {
 
 /// Trims, validates, and saves the GitHub PAT.
 /// On Windows: encrypts with DPAPI and stores as a base64 blob in config.toml.
-/// On non-Windows: stores in OS keyring; `github_pat_enc` holds an empty sentinel.
+/// On macOS/Linux: stores in OS keyring; `github_pat_enc` holds an empty sentinel.
 #[tauri::command]
 pub fn set_github_pat(pat: String) -> Result<(), String> {
     let trimmed = pat.trim();
@@ -344,7 +355,7 @@ pub fn has_github_pat() -> Result<bool, String> {
     }
     // macOS/Linux: fall back to keyring for pre-migration PATs.
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    return Ok(pat_crypto::has_in_keyring());
+    return pat_crypto::has_in_keyring();
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     Ok(false)
 }

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -113,15 +113,15 @@ pub fn update_repository_github(
     Ok(config)
 }
 
-// ─── GitHub PAT (DPAPI encrypted → config.toml) ───────────────────────────────
+// ─── GitHub PAT storage ───────────────────────────────────────────────────────
 //
-// keyring v3.6.x on Windows has a bug: credentials written by one Entry instance
-// cannot be read by a different Entry instance (cross-entry reads return NoEntry).
-// Because every Tauri command call creates a fresh Entry, we cannot rely on keyring.
-//
-// Instead, we encrypt the PAT with Windows DPAPI (user-account-scoped; unreadable
+// Windows: keyring v3.6.x had a cross-entry-read bug (separate Entry instances
+// could not read each other's credentials), and v4 is no longer a library.
+// We encrypt the PAT with Windows DPAPI (user-account-scoped; unreadable
 // on other machines) and store the resulting base64 blob in config.toml.
-// On non-Windows the keyring crate is used directly (it works on macOS/Linux).
+//
+// macOS/Linux: use keyring-core v1 with a platform-native credential store
+// (Apple Keychain on macOS, Secret Service via D-Bus on Linux).
 
 #[cfg(target_os = "windows")]
 mod pat_crypto {
@@ -217,12 +217,36 @@ mod pat_crypto {
 
 #[cfg(not(target_os = "windows"))]
 mod pat_crypto {
+    use std::sync::Once;
+
     // Keep the same service/user pair as used before this PR for backward compatibility.
     const SERVICE: &str = "arbor_github_pat";
     const USER: &str = "github";
 
-    fn keychain_entry() -> Result<keyring::Entry, String> {
-        keyring::Entry::new(SERVICE, USER)
+    static INIT_STORE: Once = Once::new();
+
+    /// keyring-core requires a default credential store to be registered once
+    /// per process before any Entry can be created.
+    /// Store::new() returns Result<Arc<Self>>, which is unsized to Arc<dyn CredentialStore>
+    /// when passed to keyring_core::set_default_store.
+    pub(super) fn ensure_default_store() {
+        INIT_STORE.call_once(|| {
+            #[cfg(target_os = "macos")]
+            match apple_native_keyring_store::keychain::Store::new() {
+                Ok(s) => keyring_core::set_default_store(s),
+                Err(e) => eprintln!("credential store の初期化に失敗: {e}"),
+            }
+            #[cfg(target_os = "linux")]
+            match dbus_secret_service_keyring_store::Store::new() {
+                Ok(s) => keyring_core::set_default_store(s),
+                Err(e) => eprintln!("credential store の初期化に失敗: {e}"),
+            }
+        });
+    }
+
+    fn keychain_entry() -> Result<keyring_core::Entry, String> {
+        ensure_default_store();
+        keyring_core::Entry::new(SERVICE, USER)
             .map_err(|e| format!("keychain エラー: {e}"))
     }
 
@@ -242,9 +266,9 @@ mod pat_crypto {
 
     /// Removes the keyring entry. `NoEntry` is treated as success.
     pub fn delete() -> Result<(), String> {
-        match keychain_entry()?.delete_password() {
+        match keychain_entry()?.delete_credential() {
             Ok(()) => Ok(()),
-            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(keyring_core::Error::NoEntry) => Ok(()),
             Err(e) => Err(format!("{e}")),
         }
     }
@@ -407,6 +431,7 @@ mod tests {
     /// キーチェーンの書き込み → 読み取り → 削除が正常に動作することを確認する。
     /// 実際の OS キーチェーンに書き込むため、デフォルトでは #[ignore] にする。
     /// `cargo test -- --ignored keyring_roundtrip` で明示的に実行すること。
+    #[cfg(not(target_os = "windows"))]
     #[test]
     #[ignore = "実 OS キーチェーンへのアクセスが必要。cargo test -- --ignored で実行"]
     fn keyring_roundtrip() {
@@ -414,10 +439,12 @@ mod tests {
         const USER: &str = "test";
         const SECRET: &str = "roundtrip_secret_12345";
 
-        let entry = match keyring::Entry::new(SERVICE, USER) {
+        super::pat_crypto::ensure_default_store();
+
+        let entry = match keyring_core::Entry::new(SERVICE, USER) {
             Ok(e) => e,
             Err(e) => {
-                eprintln!("keyring::Entry::new failed ({e}) — skipping");
+                eprintln!("keyring_core::Entry::new failed ({e}) — skipping");
                 return;
             }
         };
@@ -443,18 +470,23 @@ mod tests {
     }
 
     /// 別の Entry インスタンスで書き込まれた値を読み取れるか確認する。
-    /// keyring v3.6.x on Windows ではこのテストが失敗する（cross-entry read が NoEntry を返す）。
-    /// そのため set_github_pat は config-file フォールバックを使用している。
+    /// keyring v3.6.x on Windows では cross-entry read が NoEntry を返す既知のバグがあったため、
+    /// Windows では DPAPI フォールバックを採用してきた。Windows ではそもそも keyring-core 依存を
+    /// 持たないため、このテストは non-Windows でのみコンパイル対象とする。
+    #[cfg(not(target_os = "windows"))]
     #[test]
+    #[ignore = "実 OS キーチェーンへのアクセスが必要。cargo test -- --ignored で実行"]
     fn keyring_cross_entry_roundtrip() {
         const SERVICE: &str = "arbor_cross_entry_test";
         const USER: &str = "arbor";
         const SECRET: &str = "cross_entry_secret_12345";
 
-        // Clean up any leftover from a previous run.
-        if let Ok(e) = keyring::Entry::new(SERVICE, USER) { let _ = e.delete_credential(); }
+        super::pat_crypto::ensure_default_store();
 
-        let entry1 = match keyring::Entry::new(SERVICE, USER) {
+        // Clean up any leftover from a previous run.
+        if let Ok(e) = keyring_core::Entry::new(SERVICE, USER) { let _ = e.delete_credential(); }
+
+        let entry1 = match keyring_core::Entry::new(SERVICE, USER) {
             Ok(e) => e,
             Err(e) => { eprintln!("entry1::new failed ({e}) — skipping"); return; }
         };
@@ -463,7 +495,7 @@ mod tests {
         }
 
         // Read with a completely separate Entry instance (simulates separate Tauri command calls).
-        let entry2 = match keyring::Entry::new(SERVICE, USER) {
+        let entry2 = match keyring_core::Entry::new(SERVICE, USER) {
             Ok(e) => e,
             Err(e) => { let _ = entry1.delete_credential(); eprintln!("entry2::new failed ({e}) — skipping"); return; }
         };
@@ -472,15 +504,7 @@ mod tests {
 
         match result {
             Ok(val) => assert_eq!(val, SECRET, "cross-entry read returned different value"),
-            Err(e) => {
-                // keyring v3.6.x on Windows fails here (NoEntry).
-                // DPAPI-encrypted config-file storage is used instead (see pat_crypto).
-                eprintln!(
-                    "keyring cross-entry read failed: {e}\n\
-                     This is a known keyring v3.6.x bug on Windows.\n\
-                     DPAPI-encrypted config-file storage is used in production."
-                );
-            }
+            Err(e) => panic!("cross-entry read failed: {e}"),
         }
     }
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -18,7 +18,7 @@ pub struct Settings {
     pub github_keychain_key: String,
     /// PAT stored as a DPAPI-encrypted, base64-encoded blob on Windows.
     /// On Windows this is tied to the current user account — not readable on other machines.
-    /// On non-Windows the keyring-core crate stores the PAT; this field holds an empty-string
+    /// On macOS/Linux the keyring-core crate stores the PAT; this field holds an empty-string
     /// sentinel (`Some("")`) as a presence marker, and may be `None` for pre-migration installs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_pat_enc: Option<String>,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -18,7 +18,7 @@ pub struct Settings {
     pub github_keychain_key: String,
     /// PAT stored as a DPAPI-encrypted, base64-encoded blob on Windows.
     /// On Windows this is tied to the current user account — not readable on other machines.
-    /// On non-Windows the keyring crate stores the PAT; this field holds an empty-string
+    /// On non-Windows the keyring-core crate stores the PAT; this field holds an empty-string
     /// sentinel (`Some("")`) as a presence marker, and may be `None` for pre-migration installs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github_pat_enc: Option<String>,


### PR DESCRIPTION
## Summary

- `keyring` v3.6.3 から `keyring-core` v1.0 への移行（[ISSUE #73](https://github.com/scottlz0310/arbor/issues/73)）
- 背景: [keyring v4.0.0](https://github.com/open-source-cooperative/keyring-rs/releases/tag/v4.0.0) 以降、`keyring` クレートはライブラリではなくサンプルアプリ化された。credential store API は `keyring-core` v1.0 に分離されたため移行が必要

## 変更内容

### 依存関係 (`src-tauri/Cargo.toml`)

- 共通の `keyring = \"3.6.3\"` を削除
- macOS: `keyring-core` + `apple-native-keyring-store` (feature: `keychain`)
- Linux: `keyring-core` + `dbus-secret-service-keyring-store` (feature: `crypto-rust`)
- Windows: DPAPI 採用のため keyring 系依存を持たない（従来通り）

### コード (`src-tauri/src/commands/config_cmd.rs`)

- non-Windows の `pat_crypto` モジュールを `keyring-core` API に置換
- `set_default_store` を `Once` で 1 回だけ呼び出して platform-native credential store を登録
  - macOS: `apple_native_keyring_store::keychain::Store::new()`
  - Linux: `dbus_secret_service_keyring_store::Store::new()`
- `delete_password()` → `delete_credential()` (keyring-core の API 名)
- `keyring::Error::NoEntry` → `keyring_core::Error::NoEntry`
- 既存の keyring 依存テスト (`keyring_roundtrip`, `keyring_cross_entry_roundtrip`) を `#[cfg(not(target_os = \"windows\"))]` でガードし、両者を `keyring_core` API に書き換え

## ⚠️ 検証範囲の限界

現状の CI は **Windows のみ** で Rust ビルドを実行している（`runs-on: windows-latest`）。**macOS/Linux 用に追加した依存と書き換えたコードは CI では検証されない**。

- Windows: \`cargo check\`, \`cargo clippy -- -D warnings\`, \`cargo test\` ローカル確認済み
- macOS / Linux: ビルド未検証（API シグネチャは crates.io / docs.rs を参照したが、推測を含む）

CI に non-Windows の Rust ビルドジョブを追加する作業は別 ISSUE として起票予定。

## Test plan

- [x] Windows ローカル: \`cargo check --manifest-path src-tauri/Cargo.toml\`
- [x] Windows ローカル: \`cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings\`
- [x] Windows ローカル: \`cargo test --manifest-path src-tauri/Cargo.toml\` (34 件 pass)
- [ ] macOS ローカルビルド（実機環境必要）
- [ ] Linux ローカルビルド（実機環境必要 / libdbus-1-dev が必要な可能性あり）
- [ ] macOS Keychain への PAT 書き込み・読み出しの実機確認
- [ ] Linux Secret Service への PAT 書き込み・読み出しの実機確認

## 関連

- Closes #73
- Closed PR: #70 (keyring v4 への自動 update PR、CI 失敗のためクローズ済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)