### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,7 @@
     "node": ">=24.15.0"
   },
   "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "lefthook"
-    ]
-  },
-  "devDependencies": {
+  "devDependencies":{
     "@tauri-apps/cli": "^2.11.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   "engines": {
     "node": ">=24.15.0"
   },
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
   "pnpm": {
-    "onlyBuiltDependencies": ["lefthook"]
+    "onlyBuiltDependencies": [
+      "lefthook"
+    ]
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=24.15.0"
   },
   "packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
-  "devDependencies":{
+  "devDependencies": {
     "@tauri-apps/cli": "^2.11.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  lefthook: true


### PR DESCRIPTION
## 概要

pnpm を v10 から v11 へアップグレード。

## 変更内容

- `packageManager` を `pnpm@10.33.2` から `pnpm@11.0.8` へ更新（Corepack 用 SHA512 ハッシュ付き）
- `pnpm-workspace.yaml` を新規作成し `allowBuilds: {lefthook: true}` を設定
- `package.json` から `pnpm.onlyBuiltDependencies` を削除（v11 では無効）

## 背景

pnpm v11 ではビルドスクリプトを持つ依存パッケージ（`lefthook` など）がデフォルトでブロックされる。
許可には `pnpm-workspace.yaml` の `allowBuilds` フィールドを使用する（`package.json` の `onlyBuiltDependencies` は v10 の設定で v11 では無効）。