### PR TITLE
fix(ai): AI Insight バックグラウンド非同期化・タイムアウト修正・Ollama offline 表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `Overview`: `aiBgRunning` state を追加し `insightLoading` との競合を解消
     - `ai_insights_loading` → `aiBgRunning = true`
     - `ai_insights_updated` → `aiBgRunning = false`
+  - Ollama 未起動時に `⚠ Ollama offline` バッジとメッセージを表示 (P3-05 UX 改善)
+    - `InsightResult` に `ollamaOffline: boolean` を追加
+    - Ollama 到達不能時は `ruleResult(true)` でフラグを立てる
+    - Overview: `ollamaOffline` state を追加しパネル常時表示 + バッジ・メッセージ表示
 
 ### feat (追加予定)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `get_ai_insights_cached`: cache miss 時の同期フェッチを廃止し、常にバックグラウンド spawn に変更
     - 起動直後に UI をブロックしない。Ollama の応答速度に依存しない設計
     - バックグラウンド開始時に `ai_insights_loading` イベントを emit して "Analyzing..." を表示
-    - 失敗時（タイムアウト含む）に `ai_insights_updated []` を emit して "Analyzing..." を解除
+    - 失敗時（タイムアウト含む）に `ai_insights_failed` を emit し、フロントのルール表示を維持
+      - 成功+空結果（全リポジトリクリーン）は引き続き `ai_insights_updated []` を emit
   - `fetch_from_ollama`: クリーンな repo（全 stat が 0）をフィルタリングしてプロンプトを削減（最大 10 件）
     - フィルタ後が空の場合は即 `Ok([])` を返す（Ollama 不要）
   - `AiConfig::default()`: `timeout_secs` を 30 → 120 に変更
   - `Overview`: `aiBgRunning` state を追加し `insightLoading` との競合を解消
     - `ai_insights_loading` → `aiBgRunning = true`
     - `ai_insights_updated` → `aiBgRunning = false`
+  - `fetchInsights`: `getAiInsightsCached` が `[]` を返した場合（cache miss またはクリーン）にルール結果を placeholder として返す
+    - AI 成功時は `ai_insights_updated` イベントで上書き、失敗時は `ai_insights_failed` でルール維持
+    - `Overview`: `ai_insights_failed` リスナーを追加（`aiBgRunning = false` のみ、insights をクリアしない）
   - Ollama 未起動時に `⚠ Ollama offline` バッジとメッセージを表示 (P3-05 UX 改善)
     - `InsightResult` に `ollamaOffline: boolean` を追加
     - Ollama 到達不能時は `ruleResult(true)` でフラグを立てる

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ## [Unreleased]
 
+### fix (修正予定)
+
+- **AI Insight — バックグラウンド非同期化 & タイムアウト修正**
+  - `get_ai_insights_cached`: cache miss 時の同期フェッチを廃止し、常にバックグラウンド spawn に変更
+    - 起動直後に UI をブロックしない。Ollama の応答速度に依存しない設計
+    - バックグラウンド開始時に `ai_insights_loading` イベントを emit して "Analyzing..." を表示
+    - 失敗時（タイムアウト含む）に `ai_insights_updated []` を emit して "Analyzing..." を解除
+  - `fetch_from_ollama`: クリーンな repo（全 stat が 0）をフィルタリングしてプロンプトを削減（最大 10 件）
+    - フィルタ後が空の場合は即 `Ok([])` を返す（Ollama 不要）
+  - `AiConfig::default()`: `timeout_secs` を 30 → 120 に変更
+  - `Overview`: `aiBgRunning` state を追加し `insightLoading` との競合を解消
+    - `ai_insights_loading` → `aiBgRunning = true`
+    - `ai_insights_updated` → `aiBgRunning = false`
+
 ### feat (追加予定)
 
 - **Phase 3 — AI 設定 UI** ([#101](https://github.com/scottlz0310/arbor/issues/101))

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -155,7 +155,20 @@ async fn fetch_from_ollama(repos: &[RepoInfo]) -> Result<Vec<AiInsight>, String>
         return Err("AI Insight は設定で無効化されています".to_string());
     }
 
-    let state_json = build_state_summary(repos);
+    // クリーンな repo を除外してプロンプトサイズとレイテンシを削減する。
+    // behind/ahead/modified/untracked/stash が全て 0 の repo は AI が分析する情報がない。
+    let interesting: Vec<&RepoInfo> = repos
+        .iter()
+        .filter(|r| r.behind > 0 || r.ahead > 0 || r.modified_count > 0 || r.untracked_count > 0 || r.stash_count > 0)
+        .collect();
+
+    if interesting.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // プロンプトサイズの上限として最大 10 repos に絞る。
+    let interesting_owned: Vec<RepoInfo> = interesting.into_iter().take(10).cloned().collect();
+    let state_json = build_state_summary(&interesting_owned);
     let prompt = build_prompt(&state_json);
     let url = ollama_url(&ai.ollama_url, GENERATE_PATH);
 
@@ -292,20 +305,49 @@ pub async fn get_ai_insights_cached(
         return Ok(stale);
     }
 
-    // Cache miss: 同期フェッチ → 保存 → 返却。
-    let insights = fetch_from_ollama(&repos).await?;
+    // Cache miss: 同期フェッチをせずバックグラウンドで生成し、完了後に emit する。
+    // これにより UI スレッドをブロックせず、Ollama の応答速度に関わらず即座に返る。
     {
         let mut entries = cache.entries.lock().map_err(|e| e.to_string())?;
         entries.insert(
             key,
             CacheEntry {
-                insights: insights.clone(),
+                insights: vec![],
                 updated_at: Instant::now(),
-                refresh_in_progress: false,
+                refresh_in_progress: true,
             },
         );
     }
-    Ok(insights)
+    let repos_bg = repos.clone();
+    let app_bg = app.clone();
+    // バックグラウンド処理開始をフロントに通知して "Analyzing..." を表示させる。
+    let _ = app.emit("ai_insights_loading", ());
+    tokio::spawn(async move {
+        let cache_bg = app_bg.state::<AiCacheState>();
+        match fetch_from_ollama(&repos_bg).await {
+            Ok(fresh) => {
+                if let Ok(mut entries) = cache_bg.entries.lock() {
+                    entries.insert(
+                        key,
+                        CacheEntry {
+                            insights: fresh.clone(),
+                            updated_at: Instant::now(),
+                            refresh_in_progress: false,
+                        },
+                    );
+                }
+                let _ = app_bg.emit("ai_insights_updated", &fresh);
+            }
+            Err(_) => {
+                if let Ok(mut entries) = cache_bg.entries.lock() {
+                    entries.remove(&key);
+                }
+                // 失敗時も空配列を emit してフロントの "Analyzing..." を解除する。
+                let _ = app_bg.emit("ai_insights_updated", &Vec::<AiInsight>::new());
+            }
+        }
+    });
+    Ok(vec![])
 }
 
 /// 指定した Ollama URL に接続できるかテストする（未保存フォーム値の確認用）。

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -342,8 +342,9 @@ pub async fn get_ai_insights_cached(
                 if let Ok(mut entries) = cache_bg.entries.lock() {
                     entries.remove(&key);
                 }
-                // 失敗時も空配列を emit してフロントの "Analyzing..." を解除する。
-                let _ = app_bg.emit("ai_insights_updated", &Vec::<AiInsight>::new());
+                // 失敗時は ai_insights_failed を emit してフロントのルール表示を維持させる。
+                // ai_insights_updated [] を使うとフロントが空結果で上書きしてしまうため区別する。
+                let _ = app_bg.emit("ai_insights_failed", ());
             }
         }
     });

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -238,7 +238,11 @@ pub async fn get_ai_insights(repos: Vec<RepoInfo>) -> Result<Vec<AiInsight>, Str
 /// - Cache hit, TTL 経過    → stale を即返却し、バックグラウンド refresh を spawn
 ///                           (in-flight dedupe: 既に refresh 中なら追加 spawn しない)
 ///                           完了後: cache 更新 → emit("ai_insights_updated")
-/// - Cache miss            → 同期フェッチ → cache 保存 → 返却
+/// - Cache miss            → `[]` を即返却し、バックグラウンド spawn で生成
+///                           開始時: emit("ai_insights_loading")
+///                           成功時: cache 保存 → emit("ai_insights_updated")
+///                           失敗時: cache entry 削除 → emit("ai_insights_failed")
+///                           フロントは失敗時にルールベース結果を維持する
 #[tauri::command]
 pub async fn get_ai_insights_cached(
     repos: Vec<RepoInfo>,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -52,7 +52,7 @@ impl Default for AiConfig {
             ollama_url: "http://localhost:11434".to_string(),
             model: "qwen3.5:latest".to_string(),
             enabled: true,
-            timeout_secs: 30,
+            timeout_secs: 120,
         }
     }
 }
@@ -112,7 +112,7 @@ mod tests {
         assert_eq!(ai.ollama_url, "http://localhost:11434");
         assert_eq!(ai.model, "qwen3.5:latest");
         assert!(ai.enabled);
-        assert_eq!(ai.timeout_secs, 30);
+        assert_eq!(ai.timeout_secs, 120);
     }
 
     #[test]

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -111,4 +111,13 @@ describe('fetchInsights', () => {
     expect(result.source).toBe('rule');
     expect(result.insights).toEqual(RULE_INSIGHTS);
   });
+
+  it('getAiInsightsCached が [] を返したとき rule フォールバック (cache miss)', async () => {
+    vi.mocked(invoke.ollamaAvailable).mockResolvedValue(true);
+    vi.mocked(invoke.getAiInsightsCached).mockResolvedValue([]);
+    const result = await fetchInsights(REPOS, BRANCHES, 14);
+    expect(result.source).toBe('rule');
+    expect(result.insights).toEqual(RULE_INSIGHTS);
+    expect(result.ollamaOffline).toBe(false);
+  });
 });

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -13,6 +13,7 @@ export type InsightSource = 'ai' | 'rule';
 export interface InsightResult {
   insights: Insight[];
   source: InsightSource;
+  ollamaOffline: boolean;
 }
 
 // priority 0-3 → Insight['priority'] のマッピング
@@ -43,18 +44,19 @@ export async function fetchInsights(
   branchesByRepo: Record<string, BranchInfo[]>,
   staleDays: number,
 ): Promise<InsightResult> {
-  const ruleResult = (): InsightResult => ({
+  const ruleResult = (ollamaOffline = false): InsightResult => ({
     insights: generateInsights(repos, branchesByRepo, staleDays),
     source: 'rule',
+    ollamaOffline,
   });
 
   try {
     const available = await ollamaAvailable();
-    if (!available) return ruleResult();
+    if (!available) return ruleResult(true);
 
     const raw = await getAiInsightsCached(repos);
-    return { insights: convertAiInsights(raw), source: 'ai' };
+    return { insights: convertAiInsights(raw), source: 'ai', ollamaOffline: false };
   } catch {
-    return ruleResult();
+    return ruleResult(false);
   }
 }

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -55,6 +55,9 @@ export async function fetchInsights(
     if (!available) return ruleResult(true);
 
     const raw = await getAiInsightsCached(repos);
+    // raw=[] はキャッシュミス（バックグラウンド生成中）か全リポジトリがクリーンな場合。
+    // どちらもルール結果を返す。AI が成功すれば ai_insights_updated イベントで上書きされる。
+    if (raw.length === 0) return ruleResult(false);
     return { insights: convertAiInsights(raw), source: 'ai', ollamaOffline: false };
   } catch {
     return ruleResult(false);

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -58,9 +58,14 @@ export default function Overview() {
     const unlistenLoading = listen<void>('ai_insights_loading', () => {
       setAiBgRunning(true);
     });
+    // AI 生成失敗時はルール結果を維持したまま loading を解除する。
+    const unlistenFailed = listen<void>('ai_insights_failed', () => {
+      setAiBgRunning(false);
+    });
     return () => {
       unlistenUpdated.then((f) => f());
       unlistenLoading.then((f) => f());
+      unlistenFailed.then((f) => f());
     };
   }, []);
 

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -32,15 +32,17 @@ export default function Overview() {
   const [insightLoading, setInsightLoading] = useState(false);
   // insightLoading とは独立した state。fetchInsights の .finally() に上書きされない。
   const [aiBgRunning, setAiBgRunning]     = useState(false);
+  const [ollamaOffline, setOllamaOffline] = useState(false);
 
   // インサイトを取得 — repos が変わるたびに再計算 (branchesByRepo は Overview では省略)
   useEffect(() => {
-    if (repos.length === 0) { setInsights([]); return; }
+    if (repos.length === 0) { setInsights([]); setOllamaOffline(false); return; }
     setInsightLoading(true);
     fetchInsights(repos, {}, 14)
-      .then(({ insights: ins, source }) => {
+      .then(({ insights: ins, source, ollamaOffline: offline }) => {
         setInsights(ins);
         setInsightSource(source);
+        setOllamaOffline(offline);
       })
       .finally(() => setInsightLoading(false));
   }, [repos]);
@@ -182,13 +184,13 @@ export default function Overview() {
         </div>
 
         {/* Recommended Actions パネル (P3-07) */}
-        {(insightLoading || aiBgRunning || insights.length > 0) && (
+        {(insightLoading || aiBgRunning || ollamaOffline || insights.length > 0) && (
           <div style={{ marginTop: 16 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
               <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.1em' }}>
                 RECOMMENDED ACTIONS
               </span>
-              {!(insightLoading || aiBgRunning) && (
+              {!(insightLoading || aiBgRunning) && !ollamaOffline && (
                 <span style={{
                   fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
                   background: insightSource === 'ai' ? 'var(--indigo-bg2)' : 'var(--bg3)',
@@ -197,11 +199,24 @@ export default function Overview() {
                   {insightSource === 'ai' ? '✦ AI' : 'Rules'}
                 </span>
               )}
+              {ollamaOffline && (
+                <span style={{
+                  fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+                  background: 'var(--amber-bg, rgba(245,158,11,.15))',
+                  color: 'var(--amber)',
+                }}>
+                  ⚠ Ollama offline
+                </span>
+              )}
             </div>
             {(insightLoading || aiBgRunning) ? (
               <div style={{ fontSize: 11, color: 'var(--text3)' }}>Analyzing…</div>
-            ) : (
+            ) : insights.length > 0 ? (
               insights.slice(0, 5).map((ins, i) => <InsightCard key={i} insight={ins} />)
+            ) : (
+              <div style={{ fontSize: 11, color: 'var(--text3)' }}>
+                {ollamaOffline ? 'Ollama が起動していないため AI 分析を実行できません。' : 'All repositories are healthy.'}
+              </div>
             )}
           </div>
         )}

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -30,6 +30,8 @@ export default function Overview() {
   const [insights, setInsights]           = useState<Insight[]>([]);
   const [insightSource, setInsightSource] = useState<InsightSource>('rule');
   const [insightLoading, setInsightLoading] = useState(false);
+  // insightLoading とは独立した state。fetchInsights の .finally() に上書きされない。
+  const [aiBgRunning, setAiBgRunning]     = useState(false);
 
   // インサイトを取得 — repos が変わるたびに再計算 (branchesByRepo は Overview では省略)
   useEffect(() => {
@@ -45,11 +47,19 @@ export default function Overview() {
 
   // バックグラウンド refresh 完了イベントを受けてインサイトを差し替える (P3-04)
   useEffect(() => {
-    const promise = listen<AiInsight[]>('ai_insights_updated', (ev) => {
+    const unlistenUpdated = listen<AiInsight[]>('ai_insights_updated', (ev) => {
       setInsights(convertAiInsights(ev.payload));
       setInsightSource('ai');
+      setAiBgRunning(false);
     });
-    return () => { promise.then((f) => f()); };
+    // キャッシュミス時のバックグラウンド開始通知 → "Analyzing..." を表示する
+    const unlistenLoading = listen<void>('ai_insights_loading', () => {
+      setAiBgRunning(true);
+    });
+    return () => {
+      unlistenUpdated.then((f) => f());
+      unlistenLoading.then((f) => f());
+    };
   }, []);
 
   const repo = selectedRepo;
@@ -172,13 +182,13 @@ export default function Overview() {
         </div>
 
         {/* Recommended Actions パネル (P3-07) */}
-        {(insightLoading || insights.length > 0) && (
+        {(insightLoading || aiBgRunning || insights.length > 0) && (
           <div style={{ marginTop: 16 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
               <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.1em' }}>
                 RECOMMENDED ACTIONS
               </span>
-              {!insightLoading && (
+              {!(insightLoading || aiBgRunning) && (
                 <span style={{
                   fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
                   background: insightSource === 'ai' ? 'var(--indigo-bg2)' : 'var(--bg3)',
@@ -188,7 +198,7 @@ export default function Overview() {
                 </span>
               )}
             </div>
-            {insightLoading ? (
+            {(insightLoading || aiBgRunning) ? (
               <div style={{ fontSize: 11, color: 'var(--text3)' }}>Analyzing…</div>
             ) : (
               insights.slice(0, 5).map((ins, i) => <InsightCard key={i} insight={ins} />)


### PR DESCRIPTION
## Summary

- **cache miss 時の同期フェッチを廃止** し、常にバックグラウンド spawn に変更。Ollama の応答速度に関わらず UI をブロックしない
- **クリーンな repo をフィルタリング** してプロンプトサイズを削減（最大 10 件に制限）
- **`ai_insights_loading` / `ai_insights_updated` イベント** で "Analyzing..." の表示/解除を正確に制御（`aiBgRunning` state で `insightLoading` との競合を解消）
- **Ollama offline 時に `⚠ Ollama offline` バッジとメッセージを表示** (P3-05 UX 改善)
- **AI 失敗時にルールフォールバックを維持**: cache miss 失敗時は `ai_insights_failed` を emit し、ルールベースのインサイトをクリアしない
- `AiConfig::default` の `timeout_secs` を 30 → 120 に変更

## Background

実機テストで発覚した問題:
1. qwen3.5:latest (9.7B) がモデルロード込みで 14 分かかり、30 秒 timeout で必ず失敗していた
2. cache miss 時の同期フェッチが UI をブロックしており、timeout 後に "Analyzing..." が永久に残るバグがあった
3. Ollama が起動していない場合に何も表示されず、ユーザーが状態を把握できなかった
4. AI 生成失敗時に空の更新が来てルールベースの推奨アクションも消えてしまうバグがあった

## Test plan

- [ ] Ollama 起動中 → Overview に RECOMMENDED ACTIONS が表示される（"Analyzing..." → AI インサイト）
- [ ] Ollama 停止中 → `⚠ Ollama offline` バッジとメッセージが表示される。ルールベースの推奨アクションは引き続き表示される
- [ ] Ollama 起動中だが生成タイムアウト → "Analyzing..." が解除され、ルールベースの推奨アクションが表示される
- [ ] Settings > AI Engine > Test Connection → 接続結果がインラインで表示される
- [ ] Cleanup Wizard でブランチがある場合 → AI 理由テキストがブランチ行に表示される
- [ ] `cargo test` 59 件 / `vitest` 76 件 全通過

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)