### PR TITLE
chore: add P4-12 task for batch deregistration UI

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -176,6 +176,10 @@
 - [ ] P4-10: アクセシビリティ確認 (キーボードナビゲーション / フォーカス管理)
 - [ ] P4-11: `PullRequest` モデルに `head_sha` を追加し、CI check-runs のキーと API ref を SHA ベースに統一
        (現在は `pr.number` をキャッシュキーに使用。fork PR で同名ブランチが重複する場合の完全な解決策として Phase 4 で対応)
+- [ ] P4-12: 削除済みリポジトリの一括登録解除 UI ([#117](https://github.com/scottlz0310/arbor/issues/117))
+       - `scan_missing_repositories` コマンド追加（`Path::exists()` で存在チェック）
+       - Settings に「N件の無効なリポジトリ」バナー + チェックボックス一覧ダイアログ
+       - ConfirmDialog 必須。config 削除のみ、ディスク削除なし
 
 ---
 


### PR DESCRIPTION
## Summary
- 削除済みリポジトリの一括登録解除 UI タスク (P4-12) を `tasks.md` に追記

## Test plan
- [ ] `tasks.md` の内容が正しく反映されているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)