### PR TITLE
feat(settings): 削除済みリポジトリの一括登録解除 UI (P4-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ### feat (追加予定)
 
+- **削除済みリポジトリの一括登録解除 UI** ([#117](https://github.com/scottlz0310/arbor/issues/117)) (P4-12)
+  - `scan_missing_repositories` Rust コマンドを追加 — config 登録済みパスを走査し存在しないものを返す
+  - Settings 画面の REPOSITORIES セクションに警告バナーを追加 — 起動時 / Scan Folder 後に自動検出
+  - バナークリックで選択パネルを展開 — チェックボックスで個別選択、全選択 / 全解除ボタン
+  - 「N件を登録解除」ボタン → ConfirmDialog 確認後に一括 `remove_repository` → サイドバー即反映
+  - ディスク上のファイルは削除しない（config からの除外のみ）
+
 - **Phase 3 — AI 設定 UI** ([#101](https://github.com/scottlz0310/arbor/issues/101))
   - Settings 画面の AI Engine セクションを編集可能フォームに刷新 (P3-09)
     - provider / model / Ollama URL / timeout_secs を個別に編集・保存可能

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -373,7 +373,19 @@ pub fn delete_github_pat() -> Result<(), String> {
     Ok(())
 }
 
-// ─── scan_directory ───────────────────────────────────────────────────────────
+// ─── scan_directory / scan_missing_repositories ──────────────────────────────
+
+/// Returns repositories registered in config whose path no longer exists on disk.
+#[tauri::command]
+pub fn scan_missing_repositories() -> Result<Vec<RepoConfig>, String> {
+    let config = load_config()?;
+    let missing = config
+        .repositories
+        .into_iter()
+        .filter(|r| !std::path::Path::new(&r.path).exists())
+        .collect();
+    Ok(missing)
+}
 
 #[tauri::command]
 pub fn scan_directory(root: String) -> Result<Vec<String>, String> {

--- a/src-tauri/src/commands/config_cmd.rs
+++ b/src-tauri/src/commands/config_cmd.rs
@@ -375,16 +375,19 @@ pub fn delete_github_pat() -> Result<(), String> {
 
 // ─── scan_directory / scan_missing_repositories ──────────────────────────────
 
+/// Filters `repos` to those whose path does not exist on disk.
+fn filter_missing_repos(repos: Vec<RepoConfig>) -> Vec<RepoConfig> {
+    repos
+        .into_iter()
+        .filter(|r| !std::path::Path::new(&r.path).exists())
+        .collect()
+}
+
 /// Returns repositories registered in config whose path no longer exists on disk.
 #[tauri::command]
 pub fn scan_missing_repositories() -> Result<Vec<RepoConfig>, String> {
     let config = load_config()?;
-    let missing = config
-        .repositories
-        .into_iter()
-        .filter(|r| !std::path::Path::new(&r.path).exists())
-        .collect();
-    Ok(missing)
+    Ok(filter_missing_repos(config.repositories))
 }
 
 #[tauri::command]
@@ -486,7 +489,8 @@ pub fn update_ai_config(
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_from_git, parse_github_url};
+    use super::{detect_from_git, filter_missing_repos, parse_github_url};
+    use crate::config::RepoConfig;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -651,5 +655,39 @@ mod tests {
         assert_ne!(encrypted, PAT, "encrypted blob should differ from plaintext");
         let decrypted = super::pat_decrypt(&encrypted).expect("DPAPI decrypt");
         assert_eq!(decrypted, PAT, "decrypted value should match original");
+    }
+
+    fn make_repo(path: &str) -> RepoConfig {
+        RepoConfig { path: path.into(), name: path.split('/').last().unwrap_or(path).into(), github_owner: None, github_repo: None }
+    }
+
+    #[test]
+    fn filter_missing_repos_returns_only_nonexistent_paths() {
+        let existing = TempDir::new("filter-existing");
+        let repos = vec![
+            make_repo(existing.path_str()),
+            make_repo("/nonexistent/__arbor_test_missing__"),
+        ];
+        let missing = filter_missing_repos(repos);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].name, "__arbor_test_missing__");
+    }
+
+    #[test]
+    fn filter_missing_repos_empty_when_all_exist() {
+        let existing = TempDir::new("filter-all-exist");
+        let repos = vec![make_repo(existing.path_str())];
+        let missing = filter_missing_repos(repos);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn filter_missing_repos_all_missing() {
+        let repos = vec![
+            make_repo("/nonexistent/__arbor_a__"),
+            make_repo("/nonexistent/__arbor_b__"),
+        ];
+        let missing = filter_missing_repos(repos);
+        assert_eq!(missing.len(), 2);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,8 +6,8 @@ use commands::{
     ai::{get_ai_insights, get_ai_insights_cached, ollama_available, test_ai_connection, AiCacheState},
     config_cmd::{
         add_repository, delete_github_pat, detect_github_remote, get_config, has_github_pat,
-        remove_repository, scan_directory, set_github_pat, update_ai_config, update_repository_github,
-        update_settings,
+        remove_repository, scan_directory, scan_missing_repositories, set_github_pat,
+        update_ai_config, update_repository_github, update_settings,
     },
     dsx::{dsx_check, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
@@ -30,6 +30,7 @@ pub fn run() {
             update_repository_github,
             detect_github_remote,
             scan_directory,
+            scan_missing_repositories,
             update_settings,
             update_ai_config,
             // GitHub PAT

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -57,7 +57,8 @@ export function AppBtn({ variant = 'default', children, style, ...rest }: AppBtn
         borderRadius: 'var(--r)',
         background: 'none',
         color,
-        cursor: 'pointer',
+        cursor: rest.disabled ? 'not-allowed' : 'pointer',
+        opacity: rest.disabled ? 0.4 : 1,
         whiteSpace: 'nowrap',
         ...style,
       }}

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -18,6 +18,7 @@ import type {
   FetchResult,
   Issue,
   PullRequest,
+  RepoConfig,
   RepoInfo,
 } from '../types';
 
@@ -47,6 +48,9 @@ export const detectGithubRemote = (path: string) =>
 
 export const scanDirectory = (root: string) =>
   tauriInvoke<string[]>('scan_directory', { root });
+
+export const scanMissingRepositories = () =>
+  tauriInvoke<RepoConfig[]>('scan_missing_repositories');
 
 export const updateSettings = (args: {
   staleThresholdDays?: number;

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -15,6 +15,7 @@ const mockHasGithubPat = vi.spyOn(invoke, 'hasGithubPat');
 const mockSysUpdate = vi.spyOn(invoke, 'sysUpdate');
 const mockDetectGithubRemote = vi.spyOn(invoke, 'detectGithubRemote');
 const mockUpdateRepositoryGithub = vi.spyOn(invoke, 'updateRepositoryGithub');
+const mockScanMissingRepositories = vi.spyOn(invoke, 'scanMissingRepositories');
 
 const availableDsxStatus = { available: true, version: 'v0.2.3', path: '/usr/local/bin/dsx' };
 const unavailableDsxStatus = { available: false, version: null, path: null };
@@ -53,6 +54,7 @@ beforeEach(() => {
   mockSysUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 } as never);
   mockDetectGithubRemote.mockResolvedValue([null, null] as never);
   mockUpdateRepositoryGithub.mockResolvedValue(mockConfig as never);
+  mockScanMissingRepositories.mockResolvedValue([] as never);
 });
 
 describe('Settings — Repositories section', () => {

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
+
+// @tauri-apps/plugin-dialog の open をファイルレベルでモックする
+const mockOpen = vi.hoisted(() => vi.fn());
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: mockOpen }));
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Settings from './Settings';
 import ToastContainer from '../components/Toast';
@@ -16,6 +20,8 @@ const mockSysUpdate = vi.spyOn(invoke, 'sysUpdate');
 const mockDetectGithubRemote = vi.spyOn(invoke, 'detectGithubRemote');
 const mockUpdateRepositoryGithub = vi.spyOn(invoke, 'updateRepositoryGithub');
 const mockScanMissingRepositories = vi.spyOn(invoke, 'scanMissingRepositories');
+const mockRemoveRepository = vi.spyOn(invoke, 'removeRepository');
+const mockScanDirectory = vi.spyOn(invoke, 'scanDirectory');
 
 const availableDsxStatus = { available: true, version: 'v0.2.3', path: '/usr/local/bin/dsx' };
 const unavailableDsxStatus = { available: false, version: null, path: null };
@@ -55,6 +61,12 @@ beforeEach(() => {
   mockDetectGithubRemote.mockResolvedValue([null, null] as never);
   mockUpdateRepositoryGithub.mockResolvedValue(mockConfig as never);
   mockScanMissingRepositories.mockResolvedValue([] as never);
+  mockRemoveRepository.mockResolvedValue(mockConfig as never);
+  mockScanDirectory.mockResolvedValue([] as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
 });
 
 describe('Settings — Repositories section', () => {
@@ -171,5 +183,93 @@ describe('Settings — RepoCard', () => {
     const btn = await screen.findByRole('button', { name: 'Detect' });
     await userEvent.click(btn);
     expect(mockDetectGithubRemote).toHaveBeenCalledWith('/repo/arbor');
+  });
+});
+
+const missingRepo = { path: '/missing/repo', name: 'missing-repo', github_owner: null, github_repo: null };
+
+describe('Settings — 削除済みリポジトリ検出 (#117)', () => {
+  it('missing repo がある場合に警告バナーを表示する', async () => {
+    mockScanMissingRepositories.mockResolvedValue([missingRepo] as never);
+    renderSettings();
+    await screen.findByText(/1 件の無効なリポジトリを検出/);
+  });
+
+  it('missing repo がない場合はバナーを表示しない', async () => {
+    mockScanMissingRepositories.mockResolvedValue([] as never);
+    renderSettings();
+    // バナーが出ないことを確認するため、他の要素が描画されるまで待つ
+    await screen.findByText('REPOSITORIES');
+    expect(screen.queryByText(/無効なリポジトリを検出/)).not.toBeInTheDocument();
+  });
+
+  it('バナークリックでパネルが開き、repo 名とパスが表示される', async () => {
+    mockScanMissingRepositories.mockResolvedValue([missingRepo] as never);
+    renderSettings();
+    const banner = await screen.findByText(/1 件の無効なリポジトリを検出/);
+    await userEvent.click(banner);
+    expect(screen.getByText('missing-repo')).toBeInTheDocument();
+    expect(screen.getByText('/missing/repo')).toBeInTheDocument();
+  });
+
+  it('全選択で「N件を登録解除」ボタンが有効になる', async () => {
+    mockScanMissingRepositories.mockResolvedValue([missingRepo] as never);
+    renderSettings();
+    const banner = await screen.findByText(/1 件の無効なリポジトリを検出/);
+    await userEvent.click(banner);
+    // repo name でチェックボックスを特定（AI Engine の checkbox と区別）
+    const checkbox = screen.getByRole('checkbox', { name: /missing-repo/ });
+    expect(checkbox).not.toBeChecked();
+    await userEvent.click(screen.getByText('全選択'));
+    expect(checkbox).toBeChecked();
+    expect(screen.getByRole('button', { name: /1 件を登録解除/ })).not.toBeDisabled();
+  });
+
+  it('全解除でチェックが外れ「N件を登録解除」ボタンが disabled になる', async () => {
+    mockScanMissingRepositories.mockResolvedValue([missingRepo] as never);
+    renderSettings();
+    const banner = await screen.findByText(/1 件の無効なリポジトリを検出/);
+    await userEvent.click(banner);
+    await userEvent.click(screen.getByText('全選択'));
+    await userEvent.click(screen.getByText('全解除'));
+    const checkbox = screen.getByRole('checkbox', { name: /missing-repo/ });
+    expect(checkbox).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /0 件を登録解除/ })).toBeDisabled();
+  });
+
+  it('登録解除確認後に removeRepository が呼ばれ loadRepos が呼ばれる', async () => {
+    const mockLoadRepos = vi.fn();
+    const { useRepoStore } = await import('../stores/repoStore');
+    vi.spyOn(useRepoStore, 'getState').mockReturnValue({ loadRepos: mockLoadRepos } as never);
+
+    mockScanMissingRepositories.mockResolvedValue([missingRepo] as never);
+    renderSettings(true);
+    const banner = await screen.findByText(/1 件の無効なリポジトリを検出/);
+    await userEvent.click(banner);
+    await userEvent.click(screen.getByText('全選択'));
+    await userEvent.click(screen.getByRole('button', { name: /1 件を登録解除/ }));
+    // ConfirmDialog が開く
+    const confirmBtn = await screen.findByRole('button', { name: '登録解除' });
+    await userEvent.click(confirmBtn);
+    await waitFor(() => {
+      expect(mockRemoveRepository).toHaveBeenCalledWith('/missing/repo');
+    });
+  });
+
+  it('Scan Folder で新規 repo が 0 件でも scanMissingRepositories が呼ばれる', async () => {
+    mockOpen.mockResolvedValue('/some/folder');
+    mockScanDirectory.mockResolvedValue([] as never);
+    mockGetConfig.mockResolvedValue(mockConfig as never);
+
+    renderSettings();
+    await screen.findByText('REPOSITORIES');
+
+    const scanBtn = screen.getByRole('button', { name: /Scan Folder/ });
+    await userEvent.click(scanBtn);
+
+    await waitFor(() => {
+      // mount 時 1 回 + Scan Folder 後 1 回 = 計 2 回
+      expect(mockScanMissingRepositories).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -3,7 +3,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
-import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate, updateAiConfig, testAiConnection } from '../lib/invoke';
+import ConfirmDialog from '../components/ConfirmDialog';
+import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, scanMissingRepositories, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate, updateAiConfig, testAiConnection } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus, RepoConfig } from '../types';
 
@@ -20,6 +21,13 @@ export default function Settings() {
   const [scanResults, setScanResults] = useState<string[] | null>(null);
   const [scanSelected, setScanSelected] = useState<Set<string>>(new Set());
   const [scanning, setScanning] = useState(false);
+
+  // 削除済みリポジトリ検出
+  const [missingRepos, setMissingRepos] = useState<RepoConfig[]>([]);
+  const [missingSelected, setMissingSelected] = useState<Set<string>>(new Set());
+  const [missingPanelOpen, setMissingPanelOpen] = useState(false);
+  const [confirmDeregister, setConfirmDeregister] = useState(false);
+  const [deregistering, setDeregistering] = useState(false);
 
   // AI 設定フォームのローカルステート
   const [aiForm, setAiForm] = useState({
@@ -50,6 +58,9 @@ export default function Settings() {
     hasGithubPat()
       .then((v) => { if (!cancelled) setPatStored(v); })
       .catch(() => { if (!cancelled) setPatStored(false); });
+    scanMissingRepositories()
+      .then((missing) => { if (!cancelled) setMissingRepos(missing); })
+      .catch(() => {});
     return () => { cancelled = true; };
   }, []);
 
@@ -84,6 +95,8 @@ export default function Settings() {
       }
       setScanResults(newPaths);
       setScanSelected(new Set(newPaths));
+      // Scan Folder 後に削除済みリポジトリも再確認する
+      scanMissingRepositories().then(setMissingRepos).catch(() => {});
     } catch (e) {
       addToast(String(e), 'error');
     } finally {
@@ -216,11 +229,35 @@ export default function Settings() {
     try {
       const updated = await removeRepository(path);
       setConfig(updated);
+      setMissingRepos((prev) => prev.filter((r) => r.path !== path));
       await loadRepos();
       addToast('Repository removed', 'success');
     } catch (e) {
       addToast(String(e), 'error');
     }
+  };
+
+  const handleBulkDeregister = async () => {
+    setDeregistering(true);
+    const paths = [...missingSelected];
+    let count = 0;
+    let lastConfig: AppConfig | null = null;
+    for (const path of paths) {
+      try {
+        lastConfig = await removeRepository(path);
+        count++;
+      } catch (e) {
+        addToast(String(e), 'error');
+      }
+    }
+    if (lastConfig) setConfig(lastConfig);
+    setMissingRepos((prev) => prev.filter((r) => !missingSelected.has(r.path)));
+    setMissingSelected(new Set());
+    setMissingPanelOpen(false);
+    setConfirmDeregister(false);
+    setDeregistering(false);
+    await loadRepos();
+    if (count > 0) addToast(`${count} 件のリポジトリを登録解除しました`, 'success');
   };
 
   const aiDirty = config !== null && (
@@ -353,6 +390,103 @@ export default function Settings() {
             </AppBtn>
             <AppBtn variant="primary" onClick={handleAddRepo}>+ Add Repository</AppBtn>
           </div>
+
+          {/* 削除済みリポジトリ検出バナー (#117) */}
+          {missingRepos.length > 0 && (
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => setMissingPanelOpen((v) => !v)}
+              onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setMissingPanelOpen((v) => !v)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '8px 14px',
+                background: 'var(--amber-bg)',
+                border: '1px solid #fbbf2425',
+                borderRadius: 'var(--r)',
+                marginBottom: 10,
+                cursor: 'pointer',
+              }}
+            >
+              <span style={{ fontSize: 12, color: 'var(--amber)', flex: 1 }}>
+                ⚠ {missingRepos.length} 件の無効なリポジトリを検出
+              </span>
+              <span style={{ fontSize: 11, color: 'var(--text3)' }}>
+                {missingPanelOpen ? '▲' : '▼'}
+              </span>
+            </div>
+          )}
+
+          {/* 削除済みリポジトリ選択パネル */}
+          {missingPanelOpen && missingRepos.length > 0 && (
+            <div style={{
+              background: 'var(--bg3)',
+              border: '1px solid var(--border2)',
+              borderRadius: 'var(--r2)',
+              padding: '14px 16px',
+              marginBottom: 12,
+            }}>
+              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text1)', marginBottom: 4 }}>
+                ディスク上に存在しないリポジトリ
+              </div>
+              <div style={{ fontSize: 10, color: 'var(--text3)', marginBottom: 10 }}>
+                config から削除するリポジトリを選択してください。ディスク上のファイルは削除されません。
+              </div>
+              <div style={{ display: 'flex', gap: 12, marginBottom: 8 }}>
+                <button
+                  style={{ fontSize: 11, color: 'var(--text3)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                  onClick={() => setMissingSelected(new Set(missingRepos.map((r) => r.path)))}
+                >
+                  全選択
+                </button>
+                <button
+                  style={{ fontSize: 11, color: 'var(--text3)', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                  onClick={() => setMissingSelected(new Set())}
+                >
+                  全解除
+                </button>
+              </div>
+              <div style={{ maxHeight: 200, overflowY: 'auto', marginBottom: 10 }}>
+                {missingRepos.map((r) => {
+                  const checked = missingSelected.has(r.path);
+                  return (
+                    <label
+                      key={r.path}
+                      style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 2px', cursor: 'pointer', fontSize: 12 }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => {
+                          setMissingSelected((prev) => {
+                            const next = new Set(prev);
+                            checked ? next.delete(r.path) : next.add(r.path);
+                            return next;
+                          });
+                        }}
+                      />
+                      <span style={{ color: 'var(--text1)', fontWeight: 600 }}>{r.name}</span>
+                      <span style={{ flex: 1, minWidth: 0, color: 'var(--text3)', fontFamily: 'var(--font-mono)', fontSize: 10, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {r.path}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+                <AppBtn onClick={() => { setMissingPanelOpen(false); setMissingSelected(new Set()); }}>
+                  Close
+                </AppBtn>
+                <AppBtn
+                  variant="danger"
+                  onClick={() => setConfirmDeregister(true)}
+                  disabled={missingSelected.size === 0}
+                >
+                  {missingSelected.size} 件を登録解除
+                </AppBtn>
+              </div>
+            </div>
+          )}
 
           {/* スキャン結果確認 UI (#43) */}
           {scanResults && (
@@ -526,6 +660,16 @@ export default function Settings() {
         </section>
 
       </div>
+
+      {confirmDeregister && (
+        <ConfirmDialog
+          title="リポジトリの登録解除"
+          message={`以下の ${missingSelected.size} 件のリポジトリを config から削除します。\nディスク上のファイルは削除されません。\n\n${[...missingSelected].map((p) => missingRepos.find((r) => r.path === p)?.name ?? p).join('\n')}`}
+          confirmLabel={deregistering ? '削除中…' : '登録解除'}
+          onConfirm={handleBulkDeregister}
+          onCancel={() => setConfirmDeregister(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -89,14 +89,14 @@ export default function Settings() {
       // 既登録パスを除外する
       const registered = new Set(config?.repositories.map((r) => r.path) ?? []);
       const newPaths = found.filter((p) => !registered.has(p));
+      // Scan Folder 後は新規 repo 件数に関わらず必ず missing repo を再確認する
+      scanMissingRepositories().then(setMissingRepos).catch(() => {});
       if (newPaths.length === 0) {
         addToast('新しいリポジトリは見つかりませんでした', 'success');
         return;
       }
       setScanResults(newPaths);
       setScanSelected(new Set(newPaths));
-      // Scan Folder 後に削除済みリポジトリも再確認する
-      scanMissingRepositories().then(setMissingRepos).catch(() => {});
     } catch (e) {
       addToast(String(e), 'error');
     } finally {
@@ -238,26 +238,28 @@ export default function Settings() {
   };
 
   const handleBulkDeregister = async () => {
+    if (deregistering) return;
     setDeregistering(true);
     const paths = [...missingSelected];
-    let count = 0;
+    const removedPaths = new Set<string>();
     let lastConfig: AppConfig | null = null;
     for (const path of paths) {
       try {
         lastConfig = await removeRepository(path);
-        count++;
+        removedPaths.add(path);
       } catch (e) {
         addToast(String(e), 'error');
       }
     }
     if (lastConfig) setConfig(lastConfig);
-    setMissingRepos((prev) => prev.filter((r) => !missingSelected.has(r.path)));
+    // 成功した path のみ missingRepos から除外する（失敗分は残す）
+    setMissingRepos((prev) => prev.filter((r) => !removedPaths.has(r.path)));
     setMissingSelected(new Set());
     setMissingPanelOpen(false);
     setConfirmDeregister(false);
     setDeregistering(false);
     await loadRepos();
-    if (count > 0) addToast(`${count} 件のリポジトリを登録解除しました`, 'success');
+    if (removedPaths.size > 0) addToast(`${removedPaths.size} 件のリポジトリを登録解除しました`, 'success');
   };
 
   const aiDirty = config !== null && (

--- a/tasks.md
+++ b/tasks.md
@@ -176,7 +176,7 @@
 - [ ] P4-10: アクセシビリティ確認 (キーボードナビゲーション / フォーカス管理)
 - [ ] P4-11: `PullRequest` モデルに `head_sha` を追加し、CI check-runs のキーと API ref を SHA ベースに統一
        (現在は `pr.number` をキャッシュキーに使用。fork PR で同名ブランチが重複する場合の完全な解決策として Phase 4 で対応)
-- [ ] P4-12: 削除済みリポジトリの一括登録解除 UI ([#117](https://github.com/scottlz0310/arbor/issues/117))
+- [x] P4-12: 削除済みリポジトリの一括登録解除 UI ([#117](https://github.com/scottlz0310/arbor/issues/117))
        - `scan_missing_repositories` コマンド追加（`Path::exists()` で存在チェック）
        - Settings に「N件の無効なリポジトリ」バナー + チェックボックス一覧ダイアログ
        - ConfirmDialog 必須。config 削除のみ、ディスク削除なし


### PR DESCRIPTION
## Summary

- `scan_missing_repositories` Rust コマンドを追加 — config 登録済みパスを `Path::exists()` で走査し、ディスク上に存在しないものを `Vec<RepoConfig>` で返す
- Settings の REPOSITORIES セクションに警告バナーを追加 — 起動時・Scan Folder 後に自動検出し「N件の無効なリポジトリを検出」を表示
- バナークリックで選択パネルを展開（全選択/全解除 + チェックボックス一覧）
- 「N件を登録解除」→ ConfirmDialog 確認後に一括 `remove_repository` → `loadRepos()` でサイドバー即反映
- ディスク上のファイルは削除しない（config からの除外のみ）

Closes #117

## Test plan

- [ ] アプリ起動時に `%APPDATA%\arbor\config.toml` に存在しないパスが登録されていれば、Settings の REPOSITORIES セクションに警告バナーが表示される
- [ ] バナーをクリックするとパネルが展開し、存在しないリポジトリの名前とパスが一覧表示される
- [ ] 全選択/全解除ボタンが機能する
- [ ] 「N件を登録解除」クリックで ConfirmDialog が表示される
- [ ] 確認後に対象リポジトリが config から削除され、サイドバーから消える
- [ ] キャンセルした場合は何も変更されない
- [ ] Scan Folder 実行後にも自動で再検出される
- [ ] 存在するリポジトリのみが登録されている場合はバナーが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)