### PR TITLE
feat(overview): AI Insight フェーズバッジ＆ローディングアニメーション

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ## [Unreleased]
 
+### feat (追加予定)
+
+- **AI Insight フェーズバッジ＆ローディングアニメーション** (#121)
+  - ルール計算中: `⟳ Rules…`（スピンアニメーション）
+  - AI 分析中: `✦ AI 分析中…`（パルスアニメーション）
+  - AI 失敗: `✗ AI 失敗`（アンバーバッジ）— 従来はサイレントだった
+  - Ollama オフライン: `⚠ Offline`（アンバーバッジ）
+  - 完了: `✦ AI` or `Rules`（静的バッジ）
+  - 健全状態の空メッセージを `✓ すべてのリポジトリは健全です`（緑）に変更
+  - `global.css` に `arbor-spin` / `arbor-pulse` キーフレームを追加
+
 ### fix (修正予定)
 
 - **AI Insight — バックグラウンド非同期化 & タイムアウト修正**

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -49,3 +49,15 @@ button {
   min-width: 0;
   overflow: hidden;
 }
+
+/* ─── AI Insight アニメーション ─────────────────────────── */
+@keyframes arbor-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+@keyframes arbor-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}
+.arbor-spin  { display: inline-block; animation: arbor-spin  0.9s linear infinite; }
+.arbor-pulse { display: inline-block; animation: arbor-pulse 1.2s ease-in-out infinite; }

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -37,7 +37,13 @@ export default function Overview() {
 
   // インサイトを取得 — repos が変わるたびに再計算 (branchesByRepo は Overview では省略)
   useEffect(() => {
-    if (repos.length === 0) { setInsights([]); setOllamaOffline(false); return; }
+    if (repos.length === 0) {
+      setInsights([]);
+      setOllamaOffline(false);
+      setAiBgRunning(false);
+      setAiFailed(false);
+      return;
+    }
     setInsightLoading(true);
     setAiFailed(false);
     fetchInsights(repos, {}, 14)
@@ -55,10 +61,12 @@ export default function Overview() {
       setInsights(convertAiInsights(ev.payload));
       setInsightSource('ai');
       setAiBgRunning(false);
+      setAiFailed(false);
     });
-    // キャッシュミス時のバックグラウンド開始通知 → "Analyzing..." を表示する
+    // キャッシュミス時のバックグラウンド開始通知 → 再試行中なので失敗フラグもリセット
     const unlistenLoading = listen<void>('ai_insights_loading', () => {
       setAiBgRunning(true);
+      setAiFailed(false);
     });
     // AI 生成失敗時はルール結果を維持したまま loading を解除し失敗フラグを立てる。
     const unlistenFailed = listen<void>('ai_insights_failed', () => {

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -33,11 +33,13 @@ export default function Overview() {
   // insightLoading とは独立した state。fetchInsights の .finally() に上書きされない。
   const [aiBgRunning, setAiBgRunning]     = useState(false);
   const [ollamaOffline, setOllamaOffline] = useState(false);
+  const [aiFailed, setAiFailed]           = useState(false);
 
   // インサイトを取得 — repos が変わるたびに再計算 (branchesByRepo は Overview では省略)
   useEffect(() => {
     if (repos.length === 0) { setInsights([]); setOllamaOffline(false); return; }
     setInsightLoading(true);
+    setAiFailed(false);
     fetchInsights(repos, {}, 14)
       .then(({ insights: ins, source, ollamaOffline: offline }) => {
         setInsights(ins);
@@ -58,9 +60,10 @@ export default function Overview() {
     const unlistenLoading = listen<void>('ai_insights_loading', () => {
       setAiBgRunning(true);
     });
-    // AI 生成失敗時はルール結果を維持したまま loading を解除する。
+    // AI 生成失敗時はルール結果を維持したまま loading を解除し失敗フラグを立てる。
     const unlistenFailed = listen<void>('ai_insights_failed', () => {
       setAiBgRunning(false);
+      setAiFailed(true);
     });
     return () => {
       unlistenUpdated.then((f) => f());
@@ -189,13 +192,44 @@ export default function Overview() {
         </div>
 
         {/* Recommended Actions パネル (P3-07) */}
-        {(insightLoading || aiBgRunning || ollamaOffline || insights.length > 0) && (
+        {(insightLoading || aiBgRunning || ollamaOffline || aiFailed || insights.length > 0) && (
           <div style={{ marginTop: 16 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-              <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.1em' }}>
+              <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.1em', flex: 1 }}>
                 RECOMMENDED ACTIONS
               </span>
-              {!(insightLoading || aiBgRunning) && !ollamaOffline && (
+              {/* フェーズバッジ — 状態の優先順位: loading > aiBg > failed > offline > done */}
+              {insightLoading && (
+                <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 9, color: 'var(--text3)', fontWeight: 600 }}>
+                  <span className="arbor-spin">⟳</span> Rules…
+                </span>
+              )}
+              {!insightLoading && aiBgRunning && (
+                <span style={{
+                  display: 'flex', alignItems: 'center', gap: 4,
+                  fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+                  background: 'var(--indigo-bg2)', color: 'var(--indigo-l)',
+                }}>
+                  <span className="arbor-pulse">✦</span> AI 分析中…
+                </span>
+              )}
+              {!insightLoading && !aiBgRunning && aiFailed && (
+                <span style={{
+                  fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+                  background: 'var(--amber-bg)', color: 'var(--amber)',
+                }}>
+                  ✗ AI 失敗
+                </span>
+              )}
+              {!insightLoading && !aiBgRunning && !aiFailed && ollamaOffline && (
+                <span style={{
+                  fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+                  background: 'var(--amber-bg)', color: 'var(--amber)',
+                }}>
+                  ⚠ Offline
+                </span>
+              )}
+              {!insightLoading && !aiBgRunning && !aiFailed && !ollamaOffline && (
                 <span style={{
                   fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
                   background: insightSource === 'ai' ? 'var(--indigo-bg2)' : 'var(--bg3)',
@@ -204,23 +238,24 @@ export default function Overview() {
                   {insightSource === 'ai' ? '✦ AI' : 'Rules'}
                 </span>
               )}
-              {ollamaOffline && (
-                <span style={{
-                  fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
-                  background: 'var(--amber-bg, rgba(245,158,11,.15))',
-                  color: 'var(--amber)',
-                }}>
-                  ⚠ Ollama offline
-                </span>
-              )}
             </div>
-            {(insightLoading || aiBgRunning) ? (
-              <div style={{ fontSize: 11, color: 'var(--text3)' }}>Analyzing…</div>
+            {insightLoading ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, color: 'var(--text3)' }}>
+                <span className="arbor-spin" style={{ fontSize: 13 }}>⟳</span>
+                ルール計算中…
+              </div>
             ) : insights.length > 0 ? (
               insights.slice(0, 5).map((ins, i) => <InsightCard key={i} insight={ins} />)
+            ) : aiBgRunning ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 11, color: 'var(--indigo-l)' }}>
+                <span className="arbor-pulse" style={{ fontSize: 13 }}>✦</span>
+                AI が分析中です…
+              </div>
             ) : (
-              <div style={{ fontSize: 11, color: 'var(--text3)' }}>
-                {ollamaOffline ? 'Ollama が起動していないため AI 分析を実行できません。' : 'All repositories are healthy.'}
+              <div style={{ fontSize: 11, color: ollamaOffline ? 'var(--amber)' : 'var(--green)' }}>
+                {ollamaOffline
+                  ? 'Ollama が起動していないため AI 分析を実行できません。'
+                  : '✓ すべてのリポジトリは健全です'}
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Closes #121

- AI Insight の各フェーズを明示するバッジを `RECOMMENDED ACTIONS` ヘッダーに追加
- `global.css` に `arbor-spin` / `arbor-pulse` キーフレームを追加し視覚的フィードバックを実現
- `aiFailed` state を追加し `ai_insights_failed` イベントを `✗ AI 失敗` バッジで可視化（従来はサイレント）

| フェーズ | バッジ | ボディ |
|---------|--------|--------|
| ルール計算中 | `⟳ Rules…`（スピン） | `⟳ ルール計算中…` |
| AI 分析中 | `✦ AI 分析中…`（パルス） | ルール結果 |
| AI 完了 | `✦ AI`（静的インジゴ） | AI カード |
| AI 失敗 | `✗ AI 失敗`（アンバー） | ルール結果 |
| Ollama オフライン | `⚠ Offline`（アンバー） | メッセージ |
| ルール完了 | `Rules`（静的グレー） | カード or `✓ 健全`（緑） |

## Test plan

- [ ] Ollama 起動状態で Overview を開き、ルール計算中 → AI 分析中 → AI 完了 の順にバッジが変化することを確認
- [ ] Ollama 停止状態で Overview を開き、`⚠ Offline` バッジと `✓ すべてのリポジトリは健全です`（緑）が表示されることを確認
- [ ] AI 失敗時に `✗ AI 失敗` バッジが表示されルール結果が維持されることを確認
- [ ] `pnpm test` 83件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)