### PR TITLE
feat(stash): Stash Manager — backend コマンド + UI (P4-02/03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ## [Unreleased]
 
+### feat — Phase 4
+
+- **Stash Manager** (P4-02/03) (#103)
+  - `list_stashes` / `apply_stash` / `drop_stash` Rust コマンドを追加（git2 直接実装）
+  - `StashInfo` 型を `models.rs` / `types/index.ts` に追加
+  - `src/views/Stash.tsx` — stash 一覧テーブル + Apply / Drop 操作
+  - Drop は `ConfirmDialog` 必須。操作後に `stash_count` バッジを更新
+  - Rust ユニットテスト 4 件追加（list/apply/drop の正常系）
+
 ### chore
 
 - アプリアイコンをカスタムデザインに差し替え（全サイズ再生成） (#124)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `StashInfo` 型を `models.rs` / `types/index.ts` に追加
   - `src/views/Stash.tsx` — stash 一覧テーブル + Apply / Drop 操作
   - Drop は `ConfirmDialog` 必須。操作後に `stash_count` バッジを更新
-  - Rust ユニットテスト 4 件追加（list/apply/drop の正常系）
+  - Drop の in-flight guard（`dropping` state）で二重実行・別 stash 誤削除を防止
+  - Apply 中は全ボタンを disabled（`applyingIndex` state）
+  - `useEffect` に cancelled flag を追加し repo 切り替え race を解消
+  - `ConfirmDialog` に `confirmDisabled` prop を追加
+  - Rust ユニットテスト 4 件 + フロントエンドテスト 10 件追加
 
 ### chore
 

--- a/src-tauri/src/commands/repo.rs
+++ b/src-tauri/src/commands/repo.rs
@@ -1,5 +1,5 @@
 use crate::config::{load_config, RepoConfig};
-use crate::models::{BranchInfo, CommitNode, DeleteResult, FetchResult, RepoInfo};
+use crate::models::{BranchInfo, CommitNode, DeleteResult, FetchResult, RepoInfo, StashInfo};
 use git2::{BranchType, Repository, StatusOptions};
 use std::collections::HashMap;
 
@@ -196,6 +196,40 @@ pub fn fetch_all(repo_path: String) -> Result<FetchResult, String> {
     }
 
     Ok(FetchResult { updated_refs })
+}
+
+// ─── list_stashes ─────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn list_stashes(repo_path: String) -> Result<Vec<StashInfo>, String> {
+    let mut repo = Repository::open(&repo_path).map_err(|e| e.to_string())?;
+    let mut stashes = Vec::new();
+    repo.stash_foreach(|index, message, oid| {
+        stashes.push(StashInfo {
+            index,
+            message: message.to_string(),
+            commit_id: oid.to_string(),
+        });
+        true
+    })
+    .map_err(|e| e.to_string())?;
+    Ok(stashes)
+}
+
+// ─── apply_stash ──────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn apply_stash(repo_path: String, index: usize) -> Result<(), String> {
+    let mut repo = Repository::open(&repo_path).map_err(|e| e.to_string())?;
+    repo.stash_apply(index, None).map_err(|e| e.to_string())
+}
+
+// ─── drop_stash ───────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn drop_stash(repo_path: String, index: usize) -> Result<(), String> {
+    let mut repo = Repository::open(&repo_path).map_err(|e| e.to_string())?;
+    repo.stash_drop(index).map_err(|e| e.to_string())
 }
 
 // ─── get_commit_graph ─────────────────────────────────────────────────────────
@@ -429,7 +463,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_repo_cfg, assign_lane, fetch_all, get_branches, get_commit_graph, repo_info_for_path,
+        apply_repo_cfg, apply_stash, assign_lane, drop_stash, fetch_all, get_branches,
+        get_commit_graph, list_stashes, repo_info_for_path,
     };
     use crate::config::RepoConfig;
     use crate::models::RepoInfo;
@@ -593,6 +628,67 @@ mod tests {
         let result = fetch_all(target.path_str().to_string()).expect("fetch all");
 
         assert!(result.updated_refs.iter().all(|name| name == "origin"));
+    }
+
+    // ── stash helpers ─────────────────────────────────────────────────────────
+
+    fn create_stash(repo: &mut git2::Repository, message: &str) -> git2::Oid {
+        // Modify a tracked file so there is something to stash.
+        let path = repo.workdir().expect("workdir").join("README.md");
+        std::fs::write(&path, format!("stash content: {message}\n")).expect("write");
+        let sig =
+            git2::Signature::now("Arbor Test", "arbor@example.invalid").expect("signature");
+        repo.stash_save(&sig, message, None).expect("stash save")
+    }
+
+    #[test]
+    fn list_stashes_empty_repo() {
+        let dir = init_repo_with_commit("init");
+        let stashes = list_stashes(dir.path_str().to_string()).expect("list stashes");
+        assert!(stashes.is_empty());
+    }
+
+    #[test]
+    fn list_stashes_returns_entry() {
+        let dir = init_repo_with_commit("init");
+        let mut repo = git2::Repository::open(dir.path_str()).expect("open");
+        create_stash(&mut repo, "my stash");
+        drop(repo);
+
+        let stashes = list_stashes(dir.path_str().to_string()).expect("list stashes");
+        assert_eq!(stashes.len(), 1);
+        assert_eq!(stashes[0].index, 0);
+        assert!(stashes[0].message.contains("my stash"));
+    }
+
+    #[test]
+    fn drop_stash_removes_entry() {
+        let dir = init_repo_with_commit("init");
+        let mut repo = git2::Repository::open(dir.path_str()).expect("open");
+        create_stash(&mut repo, "to drop");
+        drop(repo);
+
+        drop_stash(dir.path_str().to_string(), 0).expect("drop stash");
+
+        let stashes = list_stashes(dir.path_str().to_string()).expect("list stashes");
+        assert!(stashes.is_empty());
+    }
+
+    #[test]
+    fn apply_stash_restores_changes() {
+        let dir = init_repo_with_commit("init");
+        let mut repo = git2::Repository::open(dir.path_str()).expect("open");
+        create_stash(&mut repo, "to apply");
+        drop(repo);
+
+        apply_stash(dir.path_str().to_string(), 0).expect("apply stash");
+
+        // After apply the file has the stashed content, stash entry still exists.
+        let stashes = list_stashes(dir.path_str().to_string()).expect("list stashes");
+        assert_eq!(stashes.len(), 1, "apply keeps the stash entry");
+        let content =
+            std::fs::read_to_string(dir.path.join("README.md")).expect("read README");
+        assert!(content.contains("to apply"));
     }
 
     fn run(commits: &[(u32, &[u32])]) -> Vec<usize> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,8 @@ use commands::{
     dsx::{dsx_check, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
     repo::{
-        delete_branches, fetch_all, get_branches, get_commit_graph, get_repo_status,
-        list_repositories,
+        apply_stash, delete_branches, drop_stash, fetch_all, get_branches, get_commit_graph,
+        get_repo_status, list_repositories, list_stashes,
     },
 };
 
@@ -48,6 +48,9 @@ pub fn run() {
             delete_branches,
             fetch_all,
             get_commit_graph,
+            list_stashes,
+            apply_stash,
+            drop_stash,
             // AI / Ollama
             ollama_available,
             test_ai_connection,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -135,6 +135,17 @@ pub struct AiInsight {
     pub priority: u8,
 }
 
+/// A single git stash entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StashInfo {
+    /// Zero-based stash index (stash@{index}).
+    pub index: usize,
+    /// Stash reflog message (e.g. "WIP on main: abc1234 message").
+    pub message: String,
+    /// Full commit OID of the stash entry.
+    pub commit_id: String,
+}
+
 /// A single check run result for a commit.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckRun {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Branches from './views/Branches';
 import Graph from './views/Graph';
 import PullRequests from './views/PullRequests';
 import Cleanup from './views/Cleanup';
+import Stash from './views/Stash';
 import Settings from './views/Settings';
 import { useRepoStore } from './stores/repoStore';
 import { useUiStore } from './stores/uiStore';
@@ -73,6 +74,9 @@ export default function App() {
         )}
         {activeView === 'cleanup' && (
           <ErrorBoundary key="cleanup" viewName="Cleanup"><Cleanup /></ErrorBoundary>
+        )}
+        {activeView === 'stash' && (
+          <ErrorBoundary key="stash" viewName="Stash Manager"><Stash /></ErrorBoundary>
         )}
         {activeView === 'settings' && (
           <ErrorBoundary key="settings" viewName="Settings"><Settings /></ErrorBoundary>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -2,6 +2,7 @@ interface ConfirmDialogProps {
   title: string;
   message: string;
   confirmLabel?: string;
+  confirmDisabled?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -10,6 +11,7 @@ export default function ConfirmDialog({
   title,
   message,
   confirmLabel = 'Confirm',
+  confirmDisabled = false,
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
@@ -45,10 +47,13 @@ export default function ConfirmDialog({
           </button>
           <button
             onClick={onConfirm}
+            disabled={confirmDisabled}
             style={{
               padding: '6px 14px', fontSize: 12,
               background: 'var(--red-bg)', border: '1px solid #f8717140',
-              borderRadius: 'var(--r)', color: 'var(--red)', cursor: 'pointer',
+              borderRadius: 'var(--r)', color: 'var(--red)',
+              cursor: confirmDisabled ? 'not-allowed' : 'pointer',
+              opacity: confirmDisabled ? 0.5 : 1,
             }}
           >
             {confirmLabel}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ const NAV_ITEMS: { id: ViewId; icon: string; label: string }[] = [
   { id: 'graph',     icon: '⧖', label: 'Graph' },
   { id: 'prs',       icon: '⇄', label: 'PR / Issues' },
   { id: 'cleanup',   icon: '✦', label: 'Cleanup' },
+  { id: 'stash',     icon: '⊟', label: 'Stash' },
   { id: 'settings',  icon: '⚙', label: 'Settings' },
 ];
 

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -20,6 +20,7 @@ import type {
   PullRequest,
   RepoConfig,
   RepoInfo,
+  StashInfo,
 } from '../types';
 
 // ─── Config ──────────────────────────────────────────────────────────────────
@@ -84,6 +85,15 @@ export const fetchAll = (repoPath: string) =>
 
 export const getCommitGraph = (repoPath: string, limit?: number) =>
   tauriInvoke<CommitNode[]>('get_commit_graph', { repoPath, limit });
+
+export const listStashes = (repoPath: string) =>
+  tauriInvoke<StashInfo[]>('list_stashes', { repoPath });
+
+export const applyStash = (repoPath: string, index: number) =>
+  tauriInvoke<void>('apply_stash', { repoPath, index });
+
+export const dropStash = (repoPath: string, index: number) =>
+  tauriInvoke<void>('drop_stash', { repoPath, index });
 
 // ─── GitHub PAT ──────────────────────────────────────────────────────────────
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -145,7 +145,13 @@ export interface AiInsight {
 
 // ─── UI-only types ───────────────────────────────────────────────────────────
 
-export type ViewId = 'overview' | 'branches' | 'graph' | 'prs' | 'cleanup' | 'settings';
+export interface StashInfo {
+  index: number;
+  message: string;
+  commit_id: string;
+}
+
+export type ViewId = 'overview' | 'branches' | 'graph' | 'prs' | 'cleanup' | 'stash' | 'settings';
 
 export type InsightType = 'explain' | 'prioritize' | 'risk';
 export type InsightSource = 'rule' | 'ai';

--- a/src/views/Stash.test.tsx
+++ b/src/views/Stash.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import Stash from './Stash';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import * as invoke from '../lib/invoke';
+
+const mockListStashes = vi.spyOn(invoke, 'listStashes');
+const mockApplyStash  = vi.spyOn(invoke, 'applyStash');
+const mockDropStash   = vi.spyOn(invoke, 'dropStash');
+const mockLoadRepos   = vi.fn();
+
+function makeRepo(path = '/repo/a', name = 'repo-a') {
+  return {
+    path, name,
+    current_branch: 'main',
+    ahead: 0, behind: 0,
+    modified_count: 0, untracked_count: 0, stash_count: 2,
+    github_owner: null, github_repo: null, last_fetched_at: null,
+  };
+}
+
+function makeStash(index: number, message = `stash entry ${index}`) {
+  return { index, message, commit_id: `abc123${index}def456` };
+}
+
+function renderStash() {
+  return render(<Stash />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => {
+    useRepoStore.setState({ repos: [], selectedRepo: null, loadRepos: mockLoadRepos });
+    useUiStore.setState({ toasts: [] });
+  });
+  mockListStashes.mockResolvedValue([]);
+  mockApplyStash.mockResolvedValue(undefined);
+  mockDropStash.mockResolvedValue(undefined);
+  mockLoadRepos.mockResolvedValue(undefined);
+});
+
+describe('Stash — リポジトリ未選択', () => {
+  it('案内メッセージを表示する', () => {
+    renderStash();
+    expect(screen.getByText(/サイドバーからリポジトリを選択/)).toBeTruthy();
+  });
+
+  it('listStashes を呼ばない', () => {
+    renderStash();
+    expect(mockListStashes).not.toHaveBeenCalled();
+  });
+});
+
+describe('Stash — スタッシュなし', () => {
+  it('"スタッシュはありません" を表示する', async () => {
+    act(() => { useRepoStore.setState({ selectedRepo: makeRepo() }); });
+    renderStash();
+    await waitFor(() => {
+      expect(screen.getByText(/スタッシュはありません/)).toBeTruthy();
+    });
+  });
+});
+
+describe('Stash — スタッシュ一覧', () => {
+  beforeEach(() => {
+    mockListStashes.mockResolvedValue([makeStash(0), makeStash(1)]);
+    act(() => { useRepoStore.setState({ selectedRepo: makeRepo() }); });
+  });
+
+  it('stash エントリが表示される', async () => {
+    renderStash();
+    await waitFor(() => {
+      expect(screen.getByText('stash entry 0')).toBeTruthy();
+      expect(screen.getByText('stash entry 1')).toBeTruthy();
+    });
+  });
+
+  it('各行に Apply / Drop ボタンがある', async () => {
+    renderStash();
+    await waitFor(() => {
+      const applies = screen.getAllByRole('button', { name: 'Apply' });
+      const drops   = screen.getAllByRole('button', { name: 'Drop' });
+      expect(applies).toHaveLength(2);
+      expect(drops).toHaveLength(2);
+    });
+  });
+});
+
+describe('Stash — Apply 操作', () => {
+  beforeEach(() => {
+    mockListStashes.mockResolvedValue([makeStash(0)]);
+    act(() => { useRepoStore.setState({ selectedRepo: makeRepo() }); });
+  });
+
+  it('Apply クリックで applyStash と loadRepos が呼ばれる', async () => {
+    renderStash();
+    await waitFor(() => screen.getByRole('button', { name: 'Apply' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    await waitFor(() => {
+      expect(mockApplyStash).toHaveBeenCalledWith('/repo/a', 0);
+      expect(mockLoadRepos).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('Stash — Drop 操作', () => {
+  beforeEach(() => {
+    mockListStashes.mockResolvedValue([makeStash(0, 'WIP on main: test')]);
+    act(() => { useRepoStore.setState({ selectedRepo: makeRepo() }); });
+  });
+
+  it('Drop クリックで ConfirmDialog が表示される', async () => {
+    renderStash();
+    await waitFor(() => screen.getByRole('button', { name: 'Drop' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Drop' }));
+    expect(screen.getByText(/スタッシュを削除しますか/)).toBeTruthy();
+  });
+
+  it('Cancel で ConfirmDialog が閉じ、dropStash は呼ばれない', async () => {
+    renderStash();
+    await waitFor(() => screen.getByRole('button', { name: 'Drop' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Drop' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(mockDropStash).not.toHaveBeenCalled();
+    expect(screen.queryByText(/スタッシュを削除しますか/)).toBeNull();
+  });
+
+  it('Confirm で dropStash と loadRepos が呼ばれる', async () => {
+    renderStash();
+    await waitFor(() => screen.getByRole('button', { name: 'Drop' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Drop' }));
+    await userEvent.click(screen.getByRole('button', { name: '削除' }));
+    await waitFor(() => {
+      expect(mockDropStash).toHaveBeenCalledWith('/repo/a', 0);
+      expect(mockLoadRepos).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('Stash — repo 切り替え race', () => {
+  it('repo 切り替え後に古いレスポンスで上書きされない', async () => {
+    const repoA = makeRepo('/repo/a', 'repo-a');
+    const repoB = makeRepo('/repo/b', 'repo-b');
+
+    let resolveA!: (v: ReturnType<typeof makeStash>[]) => void;
+    mockListStashes.mockImplementationOnce(
+      () => new Promise((res) => { resolveA = res; }),
+    );
+    mockListStashes.mockResolvedValueOnce([makeStash(0, 'stash-b')]);
+
+    act(() => { useRepoStore.setState({ selectedRepo: repoA }); });
+    renderStash();
+
+    // repo B に切り替え（A の resolve より先に）
+    act(() => { useRepoStore.setState({ selectedRepo: repoB }); });
+    await waitFor(() => screen.getByText('stash-b'));
+
+    // A の古いレスポンスを後から返す → 上書きされないことを確認
+    act(() => { resolveA([makeStash(99, 'stash-a-old')]); });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText('stash-a-old')).toBeNull();
+    expect(screen.getByText('stash-b')).toBeTruthy();
+  });
+});

--- a/src/views/Stash.tsx
+++ b/src/views/Stash.tsx
@@ -13,44 +13,59 @@ export default function Stash() {
   const [stashes, setStashes] = useState<StashInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [dropTarget, setDropTarget] = useState<StashInfo | null>(null);
+  const [dropping, setDropping] = useState(false);
+  const [applyingIndex, setApplyingIndex] = useState<number | null>(null);
 
-  const load = async () => {
-    if (!selectedRepo) return;
-    setLoading(true);
-    try {
-      setStashes(await listStashes(selectedRepo.path));
-    } catch (e) {
-      addToast(String(e), 'error');
-    } finally {
-      setLoading(false);
+  useEffect(() => {
+    if (!selectedRepo) {
+      setStashes([]);
+      return;
     }
-  };
-
-  useEffect(() => { load(); }, [selectedRepo]);
+    let cancelled = false;
+    const repoPath = selectedRepo.path;
+    setLoading(true);
+    listStashes(repoPath)
+      .then((items) => { if (!cancelled) setStashes(items); })
+      .catch((e) => { if (!cancelled) addToast(String(e), 'error'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [selectedRepo?.path]);
 
   const handleApply = async (stash: StashInfo) => {
-    if (!selectedRepo) return;
+    if (!selectedRepo || applyingIndex !== null) return;
+    setApplyingIndex(stash.index);
     try {
       await applyStash(selectedRepo.path, stash.index);
       addToast(`stash@{${stash.index}} を適用しました`, 'success');
-      await load();
-      await loadRepos();
+      const [items] = await Promise.all([
+        listStashes(selectedRepo.path),
+        loadRepos(),
+      ]);
+      setStashes(items);
     } catch (e) {
       addToast(String(e), 'error');
+    } finally {
+      setApplyingIndex(null);
     }
   };
 
   const handleDrop = async () => {
-    if (!selectedRepo || !dropTarget) return;
+    if (!selectedRepo || !dropTarget || dropping) return;
+    setDropping(true);
     const target = dropTarget;
-    setDropTarget(null);
     try {
       await dropStash(selectedRepo.path, target.index);
       addToast(`stash@{${target.index}} を削除しました`, 'success');
-      await load();
-      await loadRepos();
+      const [items] = await Promise.all([
+        listStashes(selectedRepo.path),
+        loadRepos(),
+      ]);
+      setStashes(items);
     } catch (e) {
       addToast(String(e), 'error');
+    } finally {
+      setDropping(false);
+      setDropTarget(null);
     }
   };
 
@@ -92,6 +107,8 @@ export default function Stash() {
                 <StashRow
                   key={s.index}
                   stash={s}
+                  applying={applyingIndex === s.index}
+                  anyApplying={applyingIndex !== null}
                   onApply={handleApply}
                   onDrop={setDropTarget}
                 />
@@ -106,8 +123,9 @@ export default function Stash() {
           title="スタッシュを削除しますか？"
           message={`stash@{${dropTarget.index}}: ${dropTarget.message}\n\nこの操作は取り消せません。`}
           confirmLabel="削除"
+          confirmDisabled={dropping}
           onConfirm={handleDrop}
-          onCancel={() => setDropTarget(null)}
+          onCancel={() => !dropping && setDropTarget(null)}
         />
       )}
     </div>
@@ -116,21 +134,21 @@ export default function Stash() {
 
 function StashRow({
   stash,
+  applying,
+  anyApplying,
   onApply,
   onDrop,
 }: {
   stash: StashInfo;
+  applying: boolean;
+  anyApplying: boolean;
   onApply: (s: StashInfo) => void;
   onDrop: (s: StashInfo) => void;
 }) {
   return (
     <tr style={{ borderBottom: '1px solid var(--border)' }}>
       <td style={{ padding: '8px', width: 60 }}>
-        <span style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 11,
-          color: 'var(--text3)',
-        }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text3)' }}>
           stash@{'{'}{ stash.index}{'}'}
         </span>
       </td>
@@ -139,31 +157,33 @@ function StashRow({
         {stash.message}
       </td>
       <td style={{ padding: '8px' }}>
-        <span style={{
-          fontFamily: 'var(--font-mono)',
-          fontSize: 10,
-          color: 'var(--text3)',
-        }}>
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--text3)' }}>
           {stash.commit_id.slice(0, 7)}
         </span>
       </td>
       <td style={{ padding: '8px', textAlign: 'right', whiteSpace: 'nowrap' }}>
         <button
           onClick={() => onApply(stash)}
+          disabled={anyApplying}
           style={{
-            fontSize: 10, padding: '3px 10px', borderRadius: 4, cursor: 'pointer',
+            fontSize: 10, padding: '3px 10px', borderRadius: 4,
+            cursor: anyApplying ? 'not-allowed' : 'pointer',
             background: 'var(--green-bg)', color: 'var(--green)',
             border: '1px solid var(--green)', marginRight: 6,
+            opacity: anyApplying ? 0.5 : 1,
           }}
         >
-          Apply
+          {applying ? '…' : 'Apply'}
         </button>
         <button
           onClick={() => onDrop(stash)}
+          disabled={anyApplying}
           style={{
-            fontSize: 10, padding: '3px 10px', borderRadius: 4, cursor: 'pointer',
+            fontSize: 10, padding: '3px 10px', borderRadius: 4,
+            cursor: anyApplying ? 'not-allowed' : 'pointer',
             background: 'var(--red-bg)', color: 'var(--red)',
             border: '1px solid var(--red)',
+            opacity: anyApplying ? 0.5 : 1,
           }}
         >
           Drop

--- a/src/views/Stash.tsx
+++ b/src/views/Stash.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState } from 'react';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import AppBar from '../components/AppBar';
+import ConfirmDialog from '../components/ConfirmDialog';
+import { listStashes, applyStash, dropStash } from '../lib/invoke';
+import type { StashInfo } from '../types';
+
+export default function Stash() {
+  const { selectedRepo, loadRepos } = useRepoStore();
+  const { addToast } = useUiStore();
+
+  const [stashes, setStashes] = useState<StashInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [dropTarget, setDropTarget] = useState<StashInfo | null>(null);
+
+  const load = async () => {
+    if (!selectedRepo) return;
+    setLoading(true);
+    try {
+      setStashes(await listStashes(selectedRepo.path));
+    } catch (e) {
+      addToast(String(e), 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [selectedRepo]);
+
+  const handleApply = async (stash: StashInfo) => {
+    if (!selectedRepo) return;
+    try {
+      await applyStash(selectedRepo.path, stash.index);
+      addToast(`stash@{${stash.index}} を適用しました`, 'success');
+      await load();
+      await loadRepos();
+    } catch (e) {
+      addToast(String(e), 'error');
+    }
+  };
+
+  const handleDrop = async () => {
+    if (!selectedRepo || !dropTarget) return;
+    const target = dropTarget;
+    setDropTarget(null);
+    try {
+      await dropStash(selectedRepo.path, target.index);
+      addToast(`stash@{${target.index}} を削除しました`, 'success');
+      await load();
+      await loadRepos();
+    } catch (e) {
+      addToast(String(e), 'error');
+    }
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <AppBar
+        path={selectedRepo
+          ? <><span style={{ color: 'var(--text2)' }}>{selectedRepo.name}</span> · {stashes.length} stash{stashes.length !== 1 ? 'es' : ''}</>
+          : 'No repository selected'
+        }
+      />
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 16px 16px' }}>
+        {!selectedRepo ? (
+          <div style={{ padding: 24, color: 'var(--text3)', fontSize: 12 }}>
+            サイドバーからリポジトリを選択してください
+          </div>
+        ) : loading ? (
+          <div style={{ padding: 24, color: 'var(--text3)', fontSize: 12 }}>Loading…</div>
+        ) : stashes.length === 0 ? (
+          <div style={{ padding: 24, color: 'var(--text3)', fontSize: 12 }}>
+            スタッシュはありません
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                {['INDEX', 'MESSAGE', 'COMMIT', ''].map((h) => (
+                  <th key={h} style={{
+                    fontSize: 10, fontWeight: 600, color: 'var(--text3)',
+                    letterSpacing: '.08em', textAlign: 'left',
+                    padding: '10px 8px', borderBottom: '1px solid var(--border2)',
+                  }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {stashes.map((s) => (
+                <StashRow
+                  key={s.index}
+                  stash={s}
+                  onApply={handleApply}
+                  onDrop={setDropTarget}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {dropTarget && (
+        <ConfirmDialog
+          title="スタッシュを削除しますか？"
+          message={`stash@{${dropTarget.index}}: ${dropTarget.message}\n\nこの操作は取り消せません。`}
+          confirmLabel="削除"
+          onConfirm={handleDrop}
+          onCancel={() => setDropTarget(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function StashRow({
+  stash,
+  onApply,
+  onDrop,
+}: {
+  stash: StashInfo;
+  onApply: (s: StashInfo) => void;
+  onDrop: (s: StashInfo) => void;
+}) {
+  return (
+    <tr style={{ borderBottom: '1px solid var(--border)' }}>
+      <td style={{ padding: '8px', width: 60 }}>
+        <span style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 11,
+          color: 'var(--text3)',
+        }}>
+          stash@{'{'}{ stash.index}{'}'}
+        </span>
+      </td>
+      <td style={{ padding: '8px', fontSize: 12, color: 'var(--text1)', maxWidth: 360,
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {stash.message}
+      </td>
+      <td style={{ padding: '8px' }}>
+        <span style={{
+          fontFamily: 'var(--font-mono)',
+          fontSize: 10,
+          color: 'var(--text3)',
+        }}>
+          {stash.commit_id.slice(0, 7)}
+        </span>
+      </td>
+      <td style={{ padding: '8px', textAlign: 'right', whiteSpace: 'nowrap' }}>
+        <button
+          onClick={() => onApply(stash)}
+          style={{
+            fontSize: 10, padding: '3px 10px', borderRadius: 4, cursor: 'pointer',
+            background: 'var(--green-bg)', color: 'var(--green)',
+            border: '1px solid var(--green)', marginRight: 6,
+          }}
+        >
+          Apply
+        </button>
+        <button
+          onClick={() => onDrop(stash)}
+          style={{
+            fontSize: 10, padding: '3px 10px', borderRadius: 4, cursor: 'pointer',
+            background: 'var(--red-bg)', color: 'var(--red)',
+            border: '1px solid var(--red)',
+          }}
+        >
+          Drop
+        </button>
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
closes #103

## Summary

- `list_stashes` / `apply_stash` / `drop_stash` Rust コマンドを git2 で実装
- `StashInfo` 型を `models.rs` / `types/index.ts` に追加
- `src/views/Stash.tsx` 新規作成 — stash 一覧テーブル + Apply / Drop 操作
- Drop は `ConfirmDialog` 必須、操作後に `stash_count` バッジを更新（`loadRepos()` 再呼び出し）
- Sidebar に Stash ナビゲーション追加（`⊟` アイコン）
- Rust ユニットテスト 4 件追加（list 空 / list 有 / drop / apply）

## Test plan

- [ ] stash を持つリポジトリで Stash ビューに一覧が表示される
- [ ] Apply ボタンで作業ツリーに変更が適用され、stash エントリが残る
- [ ] Drop ボタンで ConfirmDialog が表示され、確認後に削除される
- [ ] 操作後に Overview の stash_count バッジが更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)