### PR TITLE
feat(ui): コマンドパレット Ctrl/Cmd+K (P4-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ### feat — Phase 4
 
+- **コマンドパレット** (P4-01) (#102)
+  - `Ctrl/Cmd+K` でパレットを開閉
+  - ビュー遷移（7 件）・リポジトリ切替をインクリメンタル検索
+  - `↑↓` でナビゲーション、`Enter` で実行、`Esc` で閉じる
+  - `uiStore` に `commandPaletteOpen` / `openCommandPalette` / `closeCommandPalette` を追加
+  - フロントエンドテスト 16 件追加
+
 - **Stash Manager** (P4-02/03) (#103)
   - `list_stashes` / `apply_stash` / `drop_stash` Rust コマンドを追加（git2 直接実装）
   - `StashInfo` 型を `models.rs` / `types/index.ts` に追加

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,9 @@ export default function App() {
   // Ctrl/Cmd+K でコマンドパレットを開閉する
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+      // e.code は物理キーに対応するため IME / 非 QWERTY レイアウトでも動作する。
+      // フォーム入力中を含む全コンテキストで優先して開く（一般的なコマンドパレット挙動）。
+      if (e.code === 'KeyK' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         commandPaletteOpen ? closeCommandPalette() : openCommandPalette();
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { listen } from '@tauri-apps/api/event';
 import Sidebar from './components/Sidebar';
 import ToastContainer from './components/Toast';
 import ErrorBoundary from './components/ErrorBoundary';
+import CommandPalette from './components/CommandPalette';
 import Overview from './views/Overview';
 import Branches from './views/Branches';
 import Graph from './views/Graph';
@@ -16,13 +17,12 @@ import { dsxCheck } from './lib/invoke';
 
 export default function App() {
   const { loadRepos } = useRepoStore();
-  const { activeView, navigate, appendDsxLine, addToast } = useUiStore();
+  const { activeView, navigate, appendDsxLine, addToast, commandPaletteOpen, openCommandPalette, closeCommandPalette } = useUiStore();
 
+  // 起動時の初期化（一度だけ実行）
   useEffect(() => {
     loadRepos();
 
-    // StrictMode では mount→unmount→mount と2回走るため、
-    // unmount 後の Promise 完了は無視するようにクリーンアップフラグで制御する。
     let cancelled = false;
 
     dsxCheck().then((status) => {
@@ -37,7 +37,6 @@ export default function App() {
       addToast('dsx CLI の確認に失敗しました。Settings を確認してください。', 'error');
     });
 
-    // dsx 進捗イベントを購読する。
     const unlisten = listen<string>('dsx_progress', (e) => {
       appendDsxLine(e.payload);
     });
@@ -47,6 +46,18 @@ export default function App() {
       unlisten.then((fn) => fn());
     };
   }, []);
+
+  // Ctrl/Cmd+K でコマンドパレットを開閉する
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        commandPaletteOpen ? closeCommandPalette() : openCommandPalette();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [commandPaletteOpen, openCommandPalette, closeCommandPalette]);
 
   // リポジトリが未登録なら Settings へ遷移する。
   const { repos } = useRepoStore();
@@ -83,6 +94,7 @@ export default function App() {
         )}
       </main>
       <ToastContainer />
+      {commandPaletteOpen && <CommandPalette />}
     </div>
   );
 }

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -5,10 +5,14 @@ import { act } from 'react';
 import CommandPalette from './CommandPalette';
 import { useRepoStore } from '../stores/repoStore';
 import { useUiStore } from '../stores/uiStore';
+import * as invoke from '../lib/invoke';
 
-const mockNavigate       = vi.fn();
-const mockSelectRepo     = vi.fn();
+const mockNavigate            = vi.fn();
+const mockSelectRepo          = vi.fn();
 const mockCloseCommandPalette = vi.fn();
+const mockAddToast            = vi.fn();
+const mockFetchAll            = vi.spyOn(invoke, 'fetchAll');
+const mockRepoUpdate          = vi.spyOn(invoke, 'repoUpdate');
 
 function makeRepo(path: string, name: string) {
   return {
@@ -22,11 +26,14 @@ function makeRepo(path: string, name: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockFetchAll.mockResolvedValue({ updated_refs: [] });
+  mockRepoUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });
   act(() => {
     useRepoStore.setState({ repos: [], selectedRepo: null, selectRepo: mockSelectRepo });
     useUiStore.setState({
       navigate: mockNavigate,
       closeCommandPalette: mockCloseCommandPalette,
+      addToast: mockAddToast,
       commandPaletteOpen: true,
     });
   });
@@ -166,4 +173,52 @@ describe('CommandPalette — 境界ケース', () => {
     await userEvent.keyboard('{Enter}');
     expect(mockNavigate).toHaveBeenCalledWith('cleanup');
   });
+
+  it('結果 0 件のとき ArrowDown/Enter は何もしない', async () => {
+    renderPalette();
+    await userEvent.type(screen.getByRole('combobox'), 'xyznotexist');
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockCloseCommandPalette).not.toHaveBeenCalled();
+  });
 });
+
+describe('CommandPalette — アクションコマンド', () => {
+  const repo = makeRepo('/repo/a', 'my-repo');
+
+  beforeEach(() => {
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: repo }); });
+  });
+
+  it('selectedRepo があるとき Fetch コマンドが表示される', () => {
+    renderPalette();
+    expect(screen.getByText('Fetch: my-repo')).toBeTruthy();
+  });
+
+  it('selectedRepo があるとき dsx Update コマンドが表示される', () => {
+    renderPalette();
+    expect(screen.getByText('dsx Update: my-repo')).toBeTruthy();
+  });
+
+  it('Fetch コマンドクリックで fetchAll が呼ばれる', async () => {
+    renderPalette();
+    await userEvent.click(screen.getByText('Fetch: my-repo'));
+    expect(mockCloseCommandPalette).toHaveBeenCalled();
+    expect(mockFetchAll).toHaveBeenCalledWith('/repo/a');
+  });
+
+  it('dsx Update コマンドクリックで repoUpdate が呼ばれる', async () => {
+    renderPalette();
+    await userEvent.click(screen.getByText('dsx Update: my-repo'));
+    expect(mockCloseCommandPalette).toHaveBeenCalled();
+    expect(mockRepoUpdate).toHaveBeenCalledWith('/repo/a');
+  });
+
+  it('selectedRepo がないとき Fetch/Update コマンドは表示されない', () => {
+    act(() => { useRepoStore.setState({ selectedRepo: null }); });
+    renderPalette();
+    expect(screen.queryByText(/Fetch:/)).toBeNull();
+    expect(screen.queryByText(/dsx Update:/)).toBeNull();
+  });
+});
+

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -1,0 +1,169 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import CommandPalette from './CommandPalette';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+
+const mockNavigate       = vi.fn();
+const mockSelectRepo     = vi.fn();
+const mockCloseCommandPalette = vi.fn();
+
+function makeRepo(path: string, name: string) {
+  return {
+    path, name,
+    current_branch: 'main',
+    ahead: 0, behind: 0,
+    modified_count: 0, untracked_count: 0, stash_count: 0,
+    github_owner: null, github_repo: null, last_fetched_at: null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => {
+    useRepoStore.setState({ repos: [], selectedRepo: null, selectRepo: mockSelectRepo });
+    useUiStore.setState({
+      navigate: mockNavigate,
+      closeCommandPalette: mockCloseCommandPalette,
+      commandPaletteOpen: true,
+    });
+  });
+});
+
+function renderPalette() {
+  return render(<CommandPalette />);
+}
+
+describe('CommandPalette — 表示', () => {
+  it('検索インプットが自動フォーカスされる', () => {
+    renderPalette();
+    expect(document.activeElement?.tagName).toBe('INPUT');
+  });
+
+  it('ビューコマンドが全件表示される', () => {
+    renderPalette();
+    expect(screen.getByText('Overview へ移動')).toBeTruthy();
+    expect(screen.getByText('Branches へ移動')).toBeTruthy();
+    expect(screen.getByText('Stash へ移動')).toBeTruthy();
+    expect(screen.getByText('Settings へ移動')).toBeTruthy();
+  });
+
+  it('リポジトリコマンドが表示される', () => {
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo('/repo/a', 'my-repo')] });
+    });
+    renderPalette();
+    expect(screen.getByText('my-repo')).toBeTruthy();
+  });
+});
+
+describe('CommandPalette — フィルタリング', () => {
+  it('クエリに一致するコマンドのみ表示される', async () => {
+    renderPalette();
+    await userEvent.type(screen.getByRole('combobox'), 'branch');
+    expect(screen.getByText('Branches へ移動')).toBeTruthy();
+    expect(screen.queryByText('Overview へ移動')).toBeNull();
+  });
+
+  it('一致なしのとき「一致するコマンドが見つかりません」を表示する', async () => {
+    renderPalette();
+    await userEvent.type(screen.getByRole('combobox'), 'xyznotexist');
+    expect(screen.getByText(/一致するコマンドが見つかりません/)).toBeTruthy();
+  });
+
+  it('リポジトリ名でフィルタできる', async () => {
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo('/repo/arbor', 'arbor'), makeRepo('/repo/other', 'other-proj')] });
+    });
+    renderPalette();
+    await userEvent.type(screen.getByRole('combobox'), 'arbor');
+    expect(screen.getByText('arbor')).toBeTruthy();
+    expect(screen.queryByText('other-proj')).toBeNull();
+  });
+});
+
+describe('CommandPalette — キーボード操作', () => {
+  it('Escape で closeCommandPalette が呼ばれる', async () => {
+    renderPalette();
+    await userEvent.keyboard('{Escape}');
+    expect(mockCloseCommandPalette).toHaveBeenCalledOnce();
+  });
+
+  it('Enter でアクティブなコマンドが実行される', async () => {
+    renderPalette();
+    // 最初のコマンド (Overview へ移動) が選択されている
+    await userEvent.keyboard('{Enter}');
+    expect(mockNavigate).toHaveBeenCalledWith('overview');
+    expect(mockCloseCommandPalette).toHaveBeenCalled();
+  });
+
+  it('↓ キーで次のコマンドへ移動し Enter で実行される', async () => {
+    renderPalette();
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+    // 2番目のコマンドは Branches
+    expect(mockNavigate).toHaveBeenCalledWith('branches');
+  });
+
+  it('↑ キーで前のコマンドへ移動する', async () => {
+    renderPalette();
+    // 2つ下へ → 1つ上へ → 2番目が選択される
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowUp}{Enter}');
+    expect(mockNavigate).toHaveBeenCalledWith('branches');
+  });
+});
+
+describe('CommandPalette — マウス操作', () => {
+  it('コマンドクリックで実行される', async () => {
+    renderPalette();
+    await userEvent.click(screen.getByText('Cleanup へ移動'));
+    expect(mockNavigate).toHaveBeenCalledWith('cleanup');
+    expect(mockCloseCommandPalette).toHaveBeenCalled();
+  });
+
+  it('リポジトリクリックで selectRepo が呼ばれる', async () => {
+    const repo = makeRepo('/repo/a', 'test-repo');
+    act(() => { useRepoStore.setState({ repos: [repo] }); });
+    renderPalette();
+    await userEvent.click(screen.getByText('test-repo'));
+    expect(mockSelectRepo).toHaveBeenCalledWith(repo);
+    expect(mockCloseCommandPalette).toHaveBeenCalled();
+  });
+
+  it('オーバーレイクリックで closeCommandPalette が呼ばれる', async () => {
+    renderPalette();
+    // role="dialog" の外側（オーバーレイ）をクリック
+    await userEvent.click(screen.getByRole('dialog'));
+    expect(mockCloseCommandPalette).toHaveBeenCalled();
+  });
+});
+
+describe('CommandPalette — 境界ケース', () => {
+  it('↑ キーは先頭で 0 のまま', async () => {
+    renderPalette();
+    await userEvent.keyboard('{ArrowUp}{Enter}');
+    expect(mockNavigate).toHaveBeenCalledWith('overview');
+  });
+
+  it('↓ キーは末尾を超えない', async () => {
+    renderPalette();
+    // ビュー 7 件を超えて押す
+    for (let i = 0; i < 20; i++) {
+      await userEvent.keyboard('{ArrowDown}');
+    }
+    await userEvent.keyboard('{Enter}');
+    // 最後のコマンドが実行される（undefined にならない）
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it('query 変更時にカーソルが 0 にリセットされる', async () => {
+    renderPalette();
+    // Branches (index 1) に移動してから絞り込む
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.type(screen.getByRole('combobox'), 'clean');
+    // Cleanup がトップに来るのでそのまま Enter
+    await userEvent.keyboard('{Enter}');
+    expect(mockNavigate).toHaveBeenCalledWith('cleanup');
+  });
+});

--- a/src/components/CommandPalette.test.tsx
+++ b/src/components/CommandPalette.test.tsx
@@ -9,6 +9,8 @@ import * as invoke from '../lib/invoke';
 
 const mockNavigate            = vi.fn();
 const mockSelectRepo          = vi.fn();
+const mockRefreshRepo         = vi.fn();
+const mockLoadRepos           = vi.fn();
 const mockCloseCommandPalette = vi.fn();
 const mockAddToast            = vi.fn();
 const mockFetchAll            = vi.spyOn(invoke, 'fetchAll');
@@ -28,8 +30,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockFetchAll.mockResolvedValue({ updated_refs: [] });
   mockRepoUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 });
+  mockRefreshRepo.mockResolvedValue(undefined);
+  mockLoadRepos.mockResolvedValue(undefined);
   act(() => {
-    useRepoStore.setState({ repos: [], selectedRepo: null, selectRepo: mockSelectRepo });
+    useRepoStore.setState({
+      repos: [], selectedRepo: null,
+      selectRepo: mockSelectRepo, refreshRepo: mockRefreshRepo, loadRepos: mockLoadRepos,
+    });
     useUiStore.setState({
       navigate: mockNavigate,
       closeCommandPalette: mockCloseCommandPalette,
@@ -200,18 +207,20 @@ describe('CommandPalette — アクションコマンド', () => {
     expect(screen.getByText('dsx Update: my-repo')).toBeTruthy();
   });
 
-  it('Fetch コマンドクリックで fetchAll が呼ばれる', async () => {
+  it('Fetch コマンドクリックで fetchAll と refreshRepo が呼ばれる', async () => {
     renderPalette();
     await userEvent.click(screen.getByText('Fetch: my-repo'));
     expect(mockCloseCommandPalette).toHaveBeenCalled();
     expect(mockFetchAll).toHaveBeenCalledWith('/repo/a');
+    expect(mockRefreshRepo).toHaveBeenCalledWith('/repo/a');
   });
 
-  it('dsx Update コマンドクリックで repoUpdate が呼ばれる', async () => {
+  it('dsx Update コマンドクリックで repoUpdate と loadRepos が呼ばれる', async () => {
     renderPalette();
     await userEvent.click(screen.getByText('dsx Update: my-repo'));
     expect(mockCloseCommandPalette).toHaveBeenCalled();
     expect(mockRepoUpdate).toHaveBeenCalledWith('/repo/a');
+    expect(mockLoadRepos).toHaveBeenCalled();
   });
 
   it('selectedRepo がないとき Fetch/Update コマンドは表示されない', () => {

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from 'react';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import type { ViewId } from '../types';
+
+interface Command {
+  id: string;
+  icon: string;
+  label: string;
+  description: string;
+  action: () => void;
+}
+
+const VIEW_COMMANDS: { id: ViewId; icon: string; label: string }[] = [
+  { id: 'overview',  icon: '◈', label: 'Overview' },
+  { id: 'branches',  icon: '⌥', label: 'Branches' },
+  { id: 'graph',     icon: '⧖', label: 'Graph' },
+  { id: 'prs',       icon: '⇄', label: 'PR / Issues' },
+  { id: 'cleanup',   icon: '✦', label: 'Cleanup' },
+  { id: 'stash',     icon: '⊟', label: 'Stash' },
+  { id: 'settings',  icon: '⚙', label: 'Settings' },
+];
+
+export default function CommandPalette() {
+  const { repos, selectRepo } = useRepoStore();
+  const { navigate, closeCommandPalette } = useUiStore();
+
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // フォーカスをインプットに当てる
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const commands: Command[] = [
+    ...VIEW_COMMANDS.map((v) => ({
+      id: `view:${v.id}`,
+      icon: v.icon,
+      label: `${v.label} へ移動`,
+      description: 'ビュー',
+      action: () => { navigate(v.id); closeCommandPalette(); },
+    })),
+    ...repos.map((r) => ({
+      id: `repo:${r.path}`,
+      icon: '⬡',
+      label: r.name,
+      description: r.path,
+      action: () => { selectRepo(r); closeCommandPalette(); },
+    })),
+  ];
+
+  const filtered = query.trim() === ''
+    ? commands
+    : commands.filter((c) =>
+        `${c.label} ${c.description}`.toLowerCase().includes(query.toLowerCase()),
+      );
+
+  // query 変更時にカーソルを先頭に戻す
+  useEffect(() => { setActiveIndex(0); }, [query]);
+
+  // アクティブ項目をスクロールして表示（jsdom では scrollIntoView が未実装のため存在確認）
+  useEffect(() => {
+    const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    if (el && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [activeIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      filtered[activeIndex]?.action();
+    } else if (e.key === 'Escape') {
+      closeCommandPalette();
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="コマンドパレット"
+      aria-modal="true"
+      onClick={closeCommandPalette}
+      style={{
+        position: 'fixed', inset: 0,
+        background: 'rgba(0,0,0,.6)',
+        display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
+        paddingTop: '15vh',
+        zIndex: 2000,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--bg2)',
+          border: '1px solid var(--border2)',
+          borderRadius: 'var(--r2)',
+          width: 560,
+          maxWidth: '90vw',
+          overflow: 'hidden',
+          boxShadow: '0 24px 64px rgba(0,0,0,.5)',
+        }}
+      >
+        {/* 検索インプット */}
+        <div style={{ display: 'flex', alignItems: 'center', padding: '12px 16px', borderBottom: '1px solid var(--border)' }}>
+          <span style={{ fontSize: 14, color: 'var(--text3)', marginRight: 10 }}>⌕</span>
+          <input
+            ref={inputRef}
+            role="combobox"
+            aria-expanded={filtered.length > 0}
+            aria-controls="command-palette-list"
+            aria-activedescendant={filtered[activeIndex] ? `cmd-${filtered[activeIndex].id}` : undefined}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="コマンドを検索…"
+            style={{
+              flex: 1, background: 'none', border: 'none', outline: 'none',
+              fontSize: 14, color: 'var(--text1)',
+            }}
+          />
+          <kbd style={{
+            fontSize: 10, padding: '2px 6px', borderRadius: 4,
+            background: 'var(--bg4)', color: 'var(--text3)',
+            border: '1px solid var(--border2)',
+          }}>Esc</kbd>
+        </div>
+
+        {/* コマンドリスト */}
+        <ul
+          id="command-palette-list"
+          ref={listRef}
+          role="listbox"
+          style={{
+            listStyle: 'none', margin: 0, padding: '4px 0',
+            maxHeight: 360, overflowY: 'auto',
+          }}
+        >
+          {filtered.length === 0 ? (
+            <li style={{ padding: '16px', fontSize: 12, color: 'var(--text3)', textAlign: 'center' }}>
+              一致するコマンドが見つかりません
+            </li>
+          ) : filtered.map((cmd, i) => (
+            <li
+              key={cmd.id}
+              id={`cmd-${cmd.id}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              onClick={cmd.action}
+              onMouseEnter={() => setActiveIndex(i)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 12,
+                padding: '8px 16px', cursor: 'pointer',
+                background: i === activeIndex ? 'var(--bg3)' : 'transparent',
+              }}
+            >
+              <span style={{ fontSize: 13, width: 18, textAlign: 'center', color: 'var(--text3)', flexShrink: 0 }}>
+                {cmd.icon}
+              </span>
+              <span style={{ flex: 1, fontSize: 13, color: 'var(--text1)' }}>
+                {cmd.label}
+              </span>
+              <span style={{
+                fontSize: 10, color: 'var(--text3)',
+                maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+              }}>
+                {cmd.description}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {/* フッター */}
+        <div style={{
+          display: 'flex', gap: 16, padding: '8px 16px',
+          borderTop: '1px solid var(--border)',
+          fontSize: 10, color: 'var(--text3)',
+        }}>
+          {[['↑↓', '移動'], ['Enter', '実行'], ['Esc', '閉じる']].map(([key, desc]) => (
+            <span key={key}>
+              <kbd style={{
+                padding: '1px 5px', borderRadius: 3,
+                background: 'var(--bg4)', border: '1px solid var(--border2)',
+                marginRight: 4,
+              }}>{key}</kbd>
+              {desc}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRepoStore } from '../stores/repoStore';
 import { useUiStore } from '../stores/uiStore';
+import { fetchAll, repoUpdate } from '../lib/invoke';
 import type { ViewId } from '../types';
 
 interface Command {
@@ -22,8 +23,8 @@ const VIEW_COMMANDS: { id: ViewId; icon: string; label: string }[] = [
 ];
 
 export default function CommandPalette() {
-  const { repos, selectRepo } = useRepoStore();
-  const { navigate, closeCommandPalette } = useUiStore();
+  const { repos, selectedRepo, selectRepo } = useRepoStore();
+  const { navigate, closeCommandPalette, addToast } = useUiStore();
 
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
@@ -43,6 +44,33 @@ export default function CommandPalette() {
       description: 'ビュー',
       action: () => { navigate(v.id); closeCommandPalette(); },
     })),
+    // 選択リポジトリへのアクション
+    ...(selectedRepo ? [
+      {
+        id: 'action:fetch',
+        icon: '↓',
+        label: `Fetch: ${selectedRepo.name}`,
+        description: 'アクション',
+        action: () => {
+          closeCommandPalette();
+          fetchAll(selectedRepo.path)
+            .then(() => addToast(`${selectedRepo.name}: fetch 完了`, 'success'))
+            .catch((e) => addToast(String(e), 'error'));
+        },
+      },
+      {
+        id: 'action:update',
+        icon: '⟳',
+        label: `dsx Update: ${selectedRepo.name}`,
+        description: 'アクション',
+        action: () => {
+          closeCommandPalette();
+          repoUpdate(selectedRepo.path)
+            .then(() => addToast(`${selectedRepo.name}: update 完了`, 'success'))
+            .catch((e) => addToast(String(e), 'error'));
+        },
+      },
+    ] : []),
     ...repos.map((r) => ({
       id: `repo:${r.path}`,
       icon: '⬡',
@@ -72,13 +100,13 @@ export default function CommandPalette() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+      if (filtered.length > 0) setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setActiveIndex((i) => Math.max(i - 1, 0));
+      if (filtered.length > 0) setActiveIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      filtered[activeIndex]?.action();
+      if (filtered.length > 0) filtered[activeIndex]?.action();
     } else if (e.key === 'Escape') {
       closeCommandPalette();
     }

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -23,7 +23,7 @@ const VIEW_COMMANDS: { id: ViewId; icon: string; label: string }[] = [
 ];
 
 export default function CommandPalette() {
-  const { repos, selectedRepo, selectRepo } = useRepoStore();
+  const { repos, selectedRepo, selectRepo, refreshRepo, loadRepos } = useRepoStore();
   const { navigate, closeCommandPalette, addToast } = useUiStore();
 
   const [query, setQuery] = useState('');
@@ -54,7 +54,10 @@ export default function CommandPalette() {
         action: () => {
           closeCommandPalette();
           fetchAll(selectedRepo.path)
-            .then(() => addToast(`${selectedRepo.name}: fetch 完了`, 'success'))
+            .then(() => {
+              addToast(`${selectedRepo.name}: fetch 完了`, 'success');
+              refreshRepo(selectedRepo.path);
+            })
             .catch((e) => addToast(String(e), 'error'));
         },
       },
@@ -66,7 +69,10 @@ export default function CommandPalette() {
         action: () => {
           closeCommandPalette();
           repoUpdate(selectedRepo.path)
-            .then(() => addToast(`${selectedRepo.name}: update 完了`, 'success'))
+            .then(() => {
+              addToast(`${selectedRepo.name}: update 完了`, 'success');
+              loadRepos();
+            })
             .catch((e) => addToast(String(e), 'error'));
         },
       },

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -6,6 +6,7 @@ interface UiStore {
   toasts: Toast[];
   dsxProgress: string[];
   dsxRunning: boolean;
+  commandPaletteOpen: boolean;
 
   navigate: (view: ViewId) => void;
   addToast: (message: string, kind?: Toast['kind']) => void;
@@ -13,6 +14,8 @@ interface UiStore {
   appendDsxLine: (line: string) => void;
   clearDsxProgress: () => void;
   setDsxRunning: (v: boolean) => void;
+  openCommandPalette: () => void;
+  closeCommandPalette: () => void;
 }
 
 let toastSeq = 0;
@@ -22,6 +25,7 @@ export const useUiStore = create<UiStore>((set) => ({
   toasts: [],
   dsxProgress: [],
   dsxRunning: false,
+  commandPaletteOpen: false,
 
   navigate: (view) => set({ activeView: view }),
 
@@ -43,4 +47,7 @@ export const useUiStore = create<UiStore>((set) => ({
   clearDsxProgress: () => set({ dsxProgress: [] }),
 
   setDsxRunning: (v) => set({ dsxRunning: v }),
+
+  openCommandPalette: () => set({ commandPaletteOpen: true }),
+  closeCommandPalette: () => set({ commandPaletteOpen: false }),
 }));


### PR DESCRIPTION
closes #102

## Summary

- `Ctrl/Cmd+K` でコマンドパレットを開閉
- ビュー遷移 7 件（Overview / Branches / Graph / PR・Issues / Cleanup / Stash / Settings）
- 登録リポジトリへの切替コマンドを動的生成
- インクリメンタル検索でビュー名・リポジトリ名・パスを絞り込み
- `↑↓` ナビ・`Enter` 実行・`Esc` 閉じ・オーバーレイクリックで閉じる
- `uiStore` に `commandPaletteOpen` / `openCommandPalette` / `closeCommandPalette` を追加
- フロントエンドテスト 16 件（表示・フィルタ・キーボード・マウス・境界ケース）

## Test plan

- [ ] `Ctrl+K` / `Cmd+K` でパレットが開閉する
- [ ] テキスト入力でコマンドが絞り込まれる
- [ ] `↑↓` でハイライトが移動し `Enter` で実行される
- [ ] ビュー遷移コマンドが正しく動作する
- [ ] リポジトリ切替コマンドが正しく動作する
- [ ] `Esc` およびオーバーレイクリックで閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)