### PR TITLE
feat(settings): dsx バージョン確認 UI (P4-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `uiStore` に `commandPaletteOpen` / `openCommandPalette` / `closeCommandPalette` を追加
   - フロントエンドテスト 16 件追加
 
+- **dsx バージョン管理 UI** (P4-04)
+  - Settings の dsx CLI セクションに「バージョン確認」ボタンを追加
+  - クリックで GitHub Releases API から最新タグを取得し現行バージョンと比較
+  - 最新版なら ✓ 表示、新バージョンがあれば `go install` コマンドを案内
+  - `dsx_latest_version` Rust コマンド追加（reqwest, 8s タイムアウト、エラー時は null）
+  - フロントエンドテスト 5 件追加
+
 - **Stash Manager** (P4-02/03) (#103)
   - `list_stashes` / `apply_stash` / `drop_stash` Rust コマンドを追加（git2 直接実装）
   - `StashInfo` 型を `models.rs` / `types/index.ts` に追加

--- a/src-tauri/src/commands/dsx.rs
+++ b/src-tauri/src/commands/dsx.rs
@@ -67,6 +67,10 @@ pub async fn dsx_latest_version() -> Option<String> {
         return None;
     }
     let json: serde_json::Value = resp.json().await.ok()?;
+    extract_tag_name(&json)
+}
+
+fn extract_tag_name(json: &serde_json::Value) -> Option<String> {
     json["tag_name"].as_str().map(|s| s.to_string())
 }
 
@@ -222,6 +226,27 @@ fn run_dsx_sync(cwd: &str, args: &[&str]) -> Result<DsxOutput, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `extract_tag_name` が "tag_name" フィールドを正しく取り出すことを検証する。
+    #[test]
+    fn extract_tag_name_returns_tag() {
+        let json = serde_json::json!({ "tag_name": "v0.3.0", "other": "ignored" });
+        assert_eq!(super::extract_tag_name(&json), Some("v0.3.0".to_string()));
+    }
+
+    /// "tag_name" フィールドがない場合は None を返すことを検証する。
+    #[test]
+    fn extract_tag_name_missing_field_returns_none() {
+        let json = serde_json::json!({ "name": "release" });
+        assert_eq!(super::extract_tag_name(&json), None);
+    }
+
+    /// "tag_name" が null の場合は None を返すことを検証する。
+    #[test]
+    fn extract_tag_name_null_field_returns_none() {
+        let json = serde_json::json!({ "tag_name": null });
+        assert_eq!(super::extract_tag_name(&json), None);
+    }
 
     /// `available` と `version` の整合性を検証する。
     /// `path` は `which`/`where` の挙動に依存するため検証しない。

--- a/src-tauri/src/commands/dsx.rs
+++ b/src-tauri/src/commands/dsx.rs
@@ -46,6 +46,30 @@ fn which_dsx() -> Option<String> {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
 }
 
+// ─── dsx_latest_version ──────────────────────────────────────────────────────
+
+/// Queries the GitHub Releases API and returns the latest dsx tag name (e.g. "v0.3.0").
+/// Returns `None` on network error, non-2xx response, or missing field — the UI
+/// handles `null` gracefully so this command never returns `Err`.
+#[tauri::command]
+pub async fn dsx_latest_version() -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(8))
+        .build()
+        .ok()?;
+    let resp = client
+        .get("https://api.github.com/repos/scottlz0310/dsx/releases/latest")
+        .header("User-Agent", "arbor-app/1.0")
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let json: serde_json::Value = resp.json().await.ok()?;
+    json["tag_name"].as_str().map(|s| s.to_string())
+}
+
 // ─── repo_update ─────────────────────────────────────────────────────────────
 
 /// Runs `dsx repo update --no-tui -j 4` in the given repository directory.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use commands::{
         remove_repository, scan_directory, scan_missing_repositories, set_github_pat,
         update_ai_config, update_repository_github, update_settings,
     },
-    dsx::{dsx_check, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
+    dsx::{dsx_check, dsx_latest_version, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
     repo::{
         apply_stash, delete_branches, drop_stash, fetch_all, get_branches, get_commit_graph,
@@ -58,6 +58,7 @@ pub fn run() {
             get_ai_insights_cached,
             // dsx
             dsx_check,
+            dsx_latest_version,
             repo_update,
             repo_cleanup_preview,
             repo_cleanup,

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -126,6 +126,9 @@ export const getCheckRuns = (owner: string, repo: string, gitRef: string) =>
 export const dsxCheck = () =>
   tauriInvoke<DsxStatus>('dsx_check');
 
+export const dsxLatestVersion = () =>
+  tauriInvoke<string | null>('dsx_latest_version');
+
 export const repoUpdate = (repoPath: string) =>
   tauriInvoke<DsxOutput>('repo_update', { repoPath });
 

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -14,6 +14,7 @@ import { useUiStore } from '../stores/uiStore';
 
 // デフォルトの invoke モックを設定する
 const mockDsxCheck = vi.spyOn(invoke, 'dsxCheck');
+const mockDsxLatestVersion = vi.spyOn(invoke, 'dsxLatestVersion');
 const mockGetConfig = vi.spyOn(invoke, 'getConfig');
 const mockHasGithubPat = vi.spyOn(invoke, 'hasGithubPat');
 const mockSysUpdate = vi.spyOn(invoke, 'sysUpdate');
@@ -57,6 +58,7 @@ beforeEach(() => {
   mockGetConfig.mockResolvedValue(mockConfig as never);
   mockHasGithubPat.mockResolvedValue(false as never);
   mockDsxCheck.mockResolvedValue(availableDsxStatus as never);
+  mockDsxLatestVersion.mockResolvedValue(null as never);
   mockSysUpdate.mockResolvedValue({ stdout: '', stderr: '', exit_code: 0 } as never);
   mockDetectGithubRemote.mockResolvedValue([null, null] as never);
   mockUpdateRepositoryGithub.mockResolvedValue(mockConfig as never);
@@ -127,6 +129,44 @@ describe('Settings — dsx CLI section', () => {
     await userEvent.click(btn);
     // Toast に error メッセージが表示される（String(Error) → "Error: network error"）
     await screen.findByText('Error: network error');
+  });
+
+  it('「バージョン確認」ボタンが表示される', async () => {
+    renderSettings();
+    await screen.findByRole('button', { name: 'バージョン確認' });
+    expect(screen.getByRole('button', { name: 'バージョン確認' })).toBeInTheDocument();
+  });
+
+  it('「バージョン確認」クリックで dsxLatestVersion が呼ばれる', async () => {
+    mockDsxLatestVersion.mockResolvedValue('v0.2.3' as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'バージョン確認' });
+    await userEvent.click(btn);
+    expect(mockDsxLatestVersion).toHaveBeenCalledOnce();
+  });
+
+  it('最新版のとき「最新版です」を表示する', async () => {
+    mockDsxLatestVersion.mockResolvedValue('v0.2.3' as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'バージョン確認' });
+    await userEvent.click(btn);
+    await screen.findByText(/最新版です/);
+  });
+
+  it('新バージョンがあるとき「利用可能」を表示する', async () => {
+    mockDsxLatestVersion.mockResolvedValue('v0.9.9' as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'バージョン確認' });
+    await userEvent.click(btn);
+    await screen.findByText(/v0\.9\.9 が利用可能/);
+  });
+
+  it('取得失敗のとき「取得できませんでした」を表示する', async () => {
+    mockDsxLatestVersion.mockRejectedValue(new Error('network') as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'バージョン確認' });
+    await userEvent.click(btn);
+    await screen.findByText(/取得できませんでした/);
   });
 });
 

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -168,6 +168,24 @@ describe('Settings — dsx CLI section', () => {
     await userEvent.click(btn);
     await screen.findByText(/取得できませんでした/);
   });
+
+  it('v0.2.10 は v0.2.9 より新しいので「最新版です」を表示する', async () => {
+    mockDsxCheck.mockResolvedValue({ available: true, version: 'v0.2.10', path: '/usr/local/bin/dsx' } as never);
+    mockDsxLatestVersion.mockResolvedValue('v0.2.9' as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'バージョン確認' });
+    await userEvent.click(btn);
+    await screen.findByText(/最新版です/);
+  });
+
+  it('v0.2.5 は v0.2.50 より古いので「利用可能」を表示する', async () => {
+    mockDsxCheck.mockResolvedValue({ available: true, version: 'v0.2.5', path: '/usr/local/bin/dsx' } as never);
+    mockDsxLatestVersion.mockResolvedValue('v0.2.50' as never);
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'バージョン確認' });
+    await userEvent.click(btn);
+    await screen.findByText(/v0\.2\.50 が利用可能/);
+  });
 });
 
 describe('Settings — GitHub PAT section', () => {

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -4,7 +4,7 @@ import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
 import ConfirmDialog from '../components/ConfirmDialog';
-import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, scanMissingRepositories, dsxCheck, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate, updateAiConfig, testAiConnection } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, scanMissingRepositories, dsxCheck, dsxLatestVersion, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate, updateAiConfig, testAiConnection } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus, RepoConfig } from '../types';
 
@@ -18,6 +18,8 @@ export default function Settings() {
   const [patInput, setPatInput]   = useState('');
   const [patLoading, setPatLoading] = useState(false);
   const [sysUpdating, setSysUpdating] = useState(false);
+  const [dsxUpdateState, setDsxUpdateState] = useState<'idle' | 'checking' | 'done' | 'error'>('idle');
+  const [latestDsxVersion, setLatestDsxVersion] = useState<string | null>(null);
   const [scanResults, setScanResults] = useState<string[] | null>(null);
   const [scanSelected, setScanSelected] = useState<Set<string>>(new Set());
   const [scanning, setScanning] = useState(false);
@@ -161,6 +163,18 @@ export default function Settings() {
     }
   };
 
+  const handleCheckDsxUpdate = async () => {
+    setDsxUpdateState('checking');
+    setLatestDsxVersion(null);
+    try {
+      const latest = await dsxLatestVersion();
+      setLatestDsxVersion(latest);
+      setDsxUpdateState('done');
+    } catch {
+      setDsxUpdateState('error');
+    }
+  };
+
   const handleSysUpdate = async () => {
     setSysUpdating(true);
     setDsxRunning(true);
@@ -295,19 +309,35 @@ export default function Settings() {
           <SectionTitle>dsx CLI</SectionTitle>
           {dsxStatus ? (
             dsxStatus.available ? (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                <div style={{ fontSize: 12, color: 'var(--green)', flex: 1 }}>
-                  ✓ dsx {dsxStatus.version} &nbsp;·&nbsp;
-                  <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text3)' }}>
-                    {dsxStatus.path}
-                  </span>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <div style={{ fontSize: 12, color: 'var(--green)', flex: 1 }}>
+                    ✓ dsx {dsxStatus.version} &nbsp;·&nbsp;
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: 'var(--text3)' }}>
+                      {dsxStatus.path}
+                    </span>
+                  </div>
+                  <AppBtn
+                    onClick={handleCheckDsxUpdate}
+                    disabled={dsxUpdateState === 'checking'}
+                  >
+                    {dsxUpdateState === 'checking' ? '確認中…' : 'バージョン確認'}
+                  </AppBtn>
+                  <AppBtn
+                    onClick={handleSysUpdate}
+                    disabled={sysUpdating}
+                  >
+                    {sysUpdating ? 'Updating…' : 'Update'}
+                  </AppBtn>
                 </div>
-                <AppBtn
-                  onClick={handleSysUpdate}
-                  disabled={sysUpdating}
-                >
-                  {sysUpdating ? 'Updating…' : 'Update'}
-                </AppBtn>
+                {dsxUpdateState === 'done' && (
+                  <DsxUpdateResult current={dsxStatus.version ?? ''} latest={latestDsxVersion} />
+                )}
+                {dsxUpdateState === 'error' && (
+                  <div style={{ fontSize: 11, color: 'var(--text3)' }}>
+                    バージョン情報を取得できませんでした
+                  </div>
+                )}
               </div>
             ) : (
               <div style={{
@@ -765,6 +795,32 @@ function RepoCard({
           owner と repo は両方設定するか、両方空にしてください
         </div>
       )}
+    </div>
+  );
+}
+
+function DsxUpdateResult({ current, latest }: { current: string; latest: string | null }) {
+  if (!latest) {
+    return (
+      <div style={{ fontSize: 11, color: 'var(--text3)' }}>
+        リリース情報が見つかりませんでした
+      </div>
+    );
+  }
+  // latest は "v0.3.0" 形式。current は "dsx v0.2.5" 等の可能性があるため
+  // 末尾の数字部分で比較する。
+  const latestNum = latest.replace(/^v/, '');
+  const isUpToDate = current.includes(latestNum);
+  return isUpToDate ? (
+    <div style={{ fontSize: 11, color: 'var(--green)' }}>
+      ✓ 最新版です（{latest}）
+    </div>
+  ) : (
+    <div style={{ fontSize: 11, color: 'var(--amber)', lineHeight: 1.6 }}>
+      ↑ {latest} が利用可能です。以下のコマンドで更新してください:<br />
+      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--indigo-l)' }}>
+        go install github.com/scottlz0310/dsx@latest
+      </span>
     </div>
   );
 }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -181,9 +181,11 @@ export default function Settings() {
     try {
       await sysUpdate();
       addToast('dsx sys update 完了', 'success');
-      // バージョンを再取得して表示を更新する
+      // バージョンを再取得して表示を更新し、古い確認結果をリセットする
       const status = await dsxCheck();
       setDsxStatus(status);
+      setDsxUpdateState('idle');
+      setLatestDsxVersion(null);
     } catch (e) {
       addToast(String(e), 'error');
     } finally {
@@ -799,19 +801,42 @@ function RepoCard({
   );
 }
 
+// "dsx v0.2.10" や "v0.3.0" から [major, minor, patch] を抽出する。
+// 解析できない場合は null を返す。
+function parseSemverLike(value: string): [number, number, number] | null {
+  const m = value.match(/v?(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+// a >= b なら正数または 0、a < b なら負数、比較不能なら null を返す。
+export function compareSemverLike(a: string, b: string): number | null {
+  const av = parseSemverLike(a);
+  const bv = parseSemverLike(b);
+  if (!av || !bv) return null;
+  for (let i = 0; i < 3; i++) {
+    if (av[i] !== bv[i]) return av[i] - bv[i];
+  }
+  return 0;
+}
+
 function DsxUpdateResult({ current, latest }: { current: string; latest: string | null }) {
   if (!latest) {
     return (
       <div style={{ fontSize: 11, color: 'var(--text3)' }}>
-        リリース情報が見つかりませんでした
+        取得できませんでした。ネットワークまたは GitHub API を確認してください。
       </div>
     );
   }
-  // latest は "v0.3.0" 形式。current は "dsx v0.2.5" 等の可能性があるため
-  // 末尾の数字部分で比較する。
-  const latestNum = latest.replace(/^v/, '');
-  const isUpToDate = current.includes(latestNum);
-  return isUpToDate ? (
+  const cmp = compareSemverLike(current, latest);
+  if (cmp === null) {
+    return (
+      <div style={{ fontSize: 11, color: 'var(--text3)' }}>
+        バージョンを比較できませんでした（current: {current}, latest: {latest}）
+      </div>
+    );
+  }
+  return cmp >= 0 ? (
     <div style={{ fontSize: 11, color: 'var(--green)' }}>
       ✓ 最新版です（{latest}）
     </div>


### PR DESCRIPTION
## Summary

- Settings の dsx CLI セクションに「バージョン確認」ボタンを追加
- クリックで GitHub Releases API（`scottlz0310/dsx`）から最新タグを取得し現行バージョンと比較
- 最新版なら `✓ 最新版です (vX.X.X)`、新バージョンがあれば `go install` コマンドをインライン表示
- `dsx_latest_version` Tauri コマンドを追加（reqwest, 8秒タイムアウト、エラー時は `null`）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src-tauri/src/commands/dsx.rs` | `dsx_latest_version` 非同期コマンド追加 |
| `src-tauri/src/lib.rs` | コマンド登録 |
| `src/lib/invoke.ts` | `dsxLatestVersion()` ラッパー追加 |
| `src/views/Settings.tsx` | dsx セクション UI 拡張 + `DsxUpdateResult` コンポーネント追加 |
| `src/views/Settings.test.tsx` | バージョン確認テスト 5 件追加（合計 26 件） |

## Test plan

- [x] `pnpm test` — 120 件パス
- [x] `cargo test` — 66 件パス
- [x] `cargo clippy` — 警告なし
- [x] `pnpm typecheck` — エラーなし
- [ ] 実機: dsx 利用可能環境でバージョン確認ボタンをクリック → 最新版 or アップデート案内が表示される

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)