### PR TITLE
feat(prs): CI check-runs を head_sha ベースに統一 (P4-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `uiStore` に `commandPaletteOpen` / `openCommandPalette` / `closeCommandPalette` を追加
   - フロントエンドテスト 16 件追加
 
+- **CI check-runs を head_sha ベースに統一** (P4-11)
+  - `PullRequest` モデル（Rust / TS）に `head_sha` フィールドを追加
+  - `RawRef` に `sha` を追加し GitHub API レスポンスから取得
+  - check-runs の queryKey / queryFn / checkMap を `head_sha` ベースに変更
+  - fork PR で同名ブランチが重複するケースの誤った CI ドット表示を解消
+  - force-push 後にキャッシュが自動無効化されるようになった
+  - Rust ユニットテスト 1 件 + フロントエンドテスト 2 件追加
+
 - **dsx バージョン管理 UI** (P4-04)
   - Settings の dsx CLI セクションに「バージョン確認」ボタンを追加
   - クリックで GitHub Releases API から最新タグを取得し現行バージョンと比較

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -146,6 +146,7 @@ struct RawUser {
 struct RawRef {
     #[serde(rename = "ref")]
     ref_name: String,
+    sha: String,
 }
 
 /// Returns pull requests for the given repository (all pages).
@@ -176,6 +177,7 @@ pub async fn get_pull_requests(
             draft: r.draft,
             merged_at: r.merged_at,
             head_ref: r.head.ref_name,
+            head_sha: r.head.sha,
             base_ref: r.base.ref_name,
         })
         .collect())
@@ -399,5 +401,27 @@ mod tests {
             r#"<https://api.github.com/repos/o/r/pulls?page=1>; rel="last""#,
         );
         assert!(parse_next_link(&headers).is_none());
+    }
+
+    /// GitHub PR API レスポンスから head.sha が正しくデシリアライズされることを検証する。
+    #[test]
+    fn raw_pull_request_deserializes_head_sha() {
+        let json = r#"{
+            "number": 42,
+            "title": "feat: add thing",
+            "state": "open",
+            "html_url": "https://github.com/o/r/pull/42",
+            "user": { "login": "alice" },
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-02T00:00:00Z",
+            "draft": false,
+            "merged_at": null,
+            "head": { "ref": "feat/thing", "sha": "abc1234def5678" },
+            "base": { "ref": "main", "sha": "deadbeef" }
+        }"#;
+        let pr: RawPullRequest = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(pr.head.sha, "abc1234def5678");
+        assert_eq!(pr.head.ref_name, "feat/thing");
+        assert_eq!(pr.base.ref_name, "main");
     }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -96,6 +96,8 @@ pub struct PullRequest {
     pub merged_at: Option<String>,
     /// Source branch name.
     pub head_ref: String,
+    /// HEAD commit SHA of the source branch.
+    pub head_sha: String,
     /// Target branch name.
     pub base_ref: String,
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,8 @@ export interface PullRequest {
   merged_at: string | null;
   /** Source branch name */
   head_ref: string;
+  /** HEAD commit SHA of the source branch */
+  head_sha: string;
   /** Target branch name */
   base_ref: string;
 }

--- a/src/views/PullRequests.test.tsx
+++ b/src/views/PullRequests.test.tsx
@@ -8,7 +8,26 @@ import { useRepoStore } from '../stores/repoStore';
 import { useUiStore } from '../stores/uiStore';
 import * as invoke from '../lib/invoke';
 
-const mockHasGithubPat = vi.spyOn(invoke, 'hasGithubPat');
+const mockHasGithubPat    = vi.spyOn(invoke, 'hasGithubPat');
+const mockGetPullRequests = vi.spyOn(invoke, 'getPullRequests');
+const mockGetCheckRuns    = vi.spyOn(invoke, 'getCheckRuns');
+
+function makePr(number: number, headSha: string, headRef = 'feat/branch') {
+  return {
+    number,
+    title: `PR #${number}`,
+    state: 'open',
+    html_url: `https://github.com/o/r/pull/${number}`,
+    user_login: 'alice',
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-02T00:00:00Z',
+    draft: false,
+    merged_at: null,
+    head_ref: headRef,
+    head_sha: headSha,
+    base_ref: 'main',
+  };
+}
 
 const baseRepo = {
   path: '/repo/a',
@@ -40,6 +59,8 @@ beforeEach(() => {
     useUiStore.setState({ activeView: 'prs', toasts: [], dsxProgress: [], dsxRunning: false });
   });
   mockHasGithubPat.mockResolvedValue(false as never);
+  mockGetPullRequests.mockResolvedValue([] as never);
+  mockGetCheckRuns.mockResolvedValue([] as never);
 });
 
 describe('PullRequests — ガード状態', () => {
@@ -97,5 +118,43 @@ describe('PullRequests — ガード状態', () => {
     expect(screen.queryByText('リポジトリを選択してください')).not.toBeInTheDocument();
     expect(screen.queryByText('GitHub PAT が設定されていません')).not.toBeInTheDocument();
     expect(screen.queryByText('このリポジトリに GitHub Owner / Repo が設定されていません')).not.toBeInTheDocument();
+  });
+});
+
+describe('PullRequests — check-runs (head_sha)', () => {
+  const repoWithGithub = { ...baseRepo, github_owner: 'scott', github_repo: 'arbor' };
+
+  beforeEach(() => {
+    mockHasGithubPat.mockResolvedValue(true as never);
+    act(() => { useRepoStore.setState({ selectedRepo: repoWithGithub }); });
+  });
+
+  it('getCheckRuns を head_ref ではなく head_sha で呼び出す', async () => {
+    const sha = 'abc1234def5678901234567890abcdef12345678';
+    mockGetPullRequests.mockResolvedValue([makePr(1, sha, 'feat/same-branch')] as never);
+    renderPullRequests();
+    // PRs タブが表示されるまで待つ
+    await screen.findByRole('button', { name: 'PRs' });
+    // TanStack Query が fetch を開始するまで待つ
+    await vi.waitFor(() => {
+      expect(mockGetCheckRuns).toHaveBeenCalledWith('scott', 'arbor', sha);
+    });
+    // branch name では呼ばれていないことを確認
+    expect(mockGetCheckRuns).not.toHaveBeenCalledWith('scott', 'arbor', 'feat/same-branch');
+  });
+
+  it('同名ブランチを持つ 2 PR がそれぞれ別の SHA で check-runs を取得する', async () => {
+    const sha1 = 'aaaa1111';
+    const sha2 = 'bbbb2222';
+    mockGetPullRequests.mockResolvedValue([
+      makePr(1, sha1, 'feat/shared'),
+      makePr(2, sha2, 'feat/shared'),
+    ] as never);
+    renderPullRequests();
+    await screen.findByRole('button', { name: 'PRs' });
+    await vi.waitFor(() => {
+      expect(mockGetCheckRuns).toHaveBeenCalledWith('scott', 'arbor', sha1);
+      expect(mockGetCheckRuns).toHaveBeenCalledWith('scott', 'arbor', sha2);
+    });
   });
 });

--- a/src/views/PullRequests.tsx
+++ b/src/views/PullRequests.tsx
@@ -42,22 +42,22 @@ export default function PullRequests() {
     refetchInterval: STALE_MS,
   });
 
-  // CI status for each open PR — keyed by PR number to avoid cache collisions
-  // (e.g. forks with identically-named branches). head_ref is used as the API ref.
+  // CI status for each open PR — keyed by head_sha to avoid collisions when
+  // fork PRs share the same branch name. Cache also auto-invalidates on force-push.
   const checkResults = useQueries({
     queries: prs.map((pr) => ({
-      queryKey: ['checks', owner, repo, pr.number],
-      queryFn: () => getCheckRuns(owner!, repo!, pr.head_ref),
+      queryKey: ['checks', owner, repo, pr.head_sha],
+      queryFn: () => getCheckRuns(owner!, repo!, pr.head_sha),
       enabled: apiEnabled && tab === 'prs',
       staleTime: STALE_MS,
       refetchInterval: STALE_MS,
     })),
   });
 
-  const checkMap = new Map<number, CiStatus>();
+  const checkMap = new Map<string, CiStatus>();
   prs.forEach((pr, i) => {
     const runs: CheckRun[] = checkResults[i]?.data ?? [];
-    checkMap.set(pr.number, deriveCheckStatus(runs));
+    checkMap.set(pr.head_sha, deriveCheckStatus(runs));
   });
 
   // ─── Guards ────────────────────────────────────────────────────────────────
@@ -194,7 +194,7 @@ function PrTable({
   checkMap,
 }: {
   prs: PullRequest[];
-  checkMap: Map<number, CiStatus>;
+  checkMap: Map<string, CiStatus>;
 }) {
   if (prs.length === 0) {
     return (
@@ -227,7 +227,7 @@ function PrTable({
           <PrRow
             key={pr.number}
             pr={pr}
-            ciStatus={checkMap.get(pr.number) ?? null}
+            ciStatus={checkMap.get(pr.head_sha) ?? null}
           />
         ))}
       </tbody>


### PR DESCRIPTION
## Summary

- `PullRequest` モデル（Rust / TS）に `head_sha` フィールドを追加
- `RawRef` に `sha` フィールドを追加し GitHub API レスポンスから取得
- check-runs の queryKey・queryFn・checkMap を `head_sha` ベースに変更
- fork PR で同名ブランチが重複しても正しい CI ステータスを表示できる
- force-push 後に SHA が変わるとキャッシュが自動的に無効化される

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src-tauri/src/models.rs` | `PullRequest` に `head_sha: String` 追加 |
| `src-tauri/src/commands/github.rs` | `RawRef` に `sha` 追加、マッピングに `head_sha` 追加、デシリアライズテスト追加 |
| `src/types/index.ts` | `PullRequest` に `head_sha: string` 追加 |
| `src/views/PullRequests.tsx` | queryKey/queryFn/checkMap を `head_sha` ベースに変更 |
| `src/views/PullRequests.test.tsx` | `head_sha` で呼び出しを検証するテスト 2 件追加 |

## Test plan

- [x] `pnpm test` — 124 件パス
- [x] `cargo test` — 70 件パス
- [x] `cargo clippy` — 警告なし
- [x] `pnpm typecheck` — エラーなし
- [x] `getCheckRuns` が `head_sha` で呼ばれることをテストで固定（`feat/same-branch` では呼ばれない）
- [x] 同名ブランチを持つ 2 PR が別々の SHA で取得されることをテストで固定

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)