### PR TITLE
feat(a11y): ConfirmDialog・Sidebar アクセシビリティ改善 (P4-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `dsx_latest_version` Rust コマンド追加（reqwest, 8s タイムアウト、エラー時は null）
   - フロントエンドテスト 5 件追加
 
+- **アクセシビリティ改善** (P4-10)
+  - `ConfirmDialog`: `role="dialog"` / `aria-modal="true"` / `aria-labelledby` 追加、フォーカストラップ、Escape キー対応、マウント時自動フォーカス、アンマウント時フォーカス復帰
+  - `Sidebar`: リポジトリ一覧に `role="region"` + `aria-label="リポジトリ一覧"`、リポジトリボタンに `aria-pressed`、nav に `aria-label="ナビゲーション"`、nav ボタンに `aria-current="page"` と `aria-label` 追加
+  - フロントエンドテスト 14 件追加（ConfirmDialog a11y 7件、Sidebar a11y 7件）
+
 - **Stash Manager** (P4-02/03) (#103)
   - `list_stashes` / `apply_stash` / `drop_stash` Rust コマンドを追加（git2 直接実装）
   - `StashInfo` 型を `models.rs` / `types/index.ts` に追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,12 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `dsx_latest_version` Rust コマンド追加（reqwest, 8s タイムアウト、エラー時は null）
   - フロントエンドテスト 5 件追加
 
-- **dsx sys update に確認ダイアログを追加** (P4-04 追加修正)
-  - Settings の「Update」ボタンクリック時に ConfirmDialog を表示し、誤実行を防止
-  - `dsx sys update --no-tui`（重い処理）を確認後のみ実行するよう変更
-  - Settings テスト 2 件追加（ダイアログ表示確認・キャンセル確認）
+- **dsx Self Update ボタン追加・Sys Update に確認ダイアログ** (P4-04 追加修正)
+  - バージョン確認で新版が見つかった場合に「Self Update」ボタンを表示し、ConfirmDialog 経由で `dsx self-update` を実行可能に
+  - `dsx_self_update` Tauri コマンド追加（`dsx self-update` を実行）
+  - 既存「Update」ボタンを「Sys Update」に改名 + tooltip 追加（dsx 管理ツール一括更新であることを明示）
+  - 「Sys Update」クリック時に ConfirmDialog を追加し誤実行を防止
+  - Settings テスト 5 件追加
 
 - **アクセシビリティ改善** (P4-10)
   - `ConfirmDialog`: `role="dialog"` / `aria-modal="true"` / `aria-labelledby` 追加、フォーカストラップ、Escape キー対応、マウント時自動フォーカス、アンマウント時フォーカス復帰

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - `dsx_latest_version` Rust コマンド追加（reqwest, 8s タイムアウト、エラー時は null）
   - フロントエンドテスト 5 件追加
 
+- **dsx sys update に確認ダイアログを追加** (P4-04 追加修正)
+  - Settings の「Update」ボタンクリック時に ConfirmDialog を表示し、誤実行を防止
+  - `dsx sys update --no-tui`（重い処理）を確認後のみ実行するよう変更
+  - Settings テスト 2 件追加（ダイアログ表示確認・キャンセル確認）
+
 - **アクセシビリティ改善** (P4-10)
   - `ConfirmDialog`: `role="dialog"` / `aria-modal="true"` / `aria-labelledby` 追加、フォーカストラップ、Escape キー対応、マウント時自動フォーカス、アンマウント時フォーカス復帰
   - `Sidebar`: リポジトリ一覧に `role="region"` + `aria-label="リポジトリ一覧"`、リポジトリボタンに `aria-pressed`、nav に `aria-label="ナビゲーション"`、nav ボタンに `aria-current="page"` と `aria-label` 追加

--- a/src-tauri/src/commands/dsx.rs
+++ b/src-tauri/src/commands/dsx.rs
@@ -147,6 +147,16 @@ pub async fn sys_update(app: AppHandle) -> Result<DsxOutput, String> {
     run_dsx_with_events(&app, ".", &["sys", "update", "--no-tui"]).await
 }
 
+// ─── dsx_self_update ──────────────────────────────────────────────────────────
+
+/// Runs `dsx self-update` to upgrade the dsx CLI binary itself.
+///
+/// Progress lines are streamed via `dsx_progress` events.
+#[tauri::command]
+pub async fn dsx_self_update(app: AppHandle) -> Result<DsxOutput, String> {
+    run_dsx_with_events(&app, ".", &["self-update"]).await
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Runs a dsx command, streaming stdout lines as `dsx_progress` events to the

--- a/src-tauri/src/commands/dsx.rs
+++ b/src-tauri/src/commands/dsx.rs
@@ -305,6 +305,19 @@ mod tests {
         assert!(!path.unwrap().is_empty());
     }
 
+    /// dsx が利用可能な場合に `self-update` サブコマンドが認識されることを確認する。
+    /// `--help` を渡すことで実際の更新は行わず、サブコマンドの存在とヘルプ出力のみ検証する。
+    #[test]
+    fn dsx_self_update_subcommand_is_recognized() {
+        if !dsx_check().available {
+            return;
+        }
+        let result = run_dsx_sync(".", &["self-update", "--help"]);
+        let output = result.expect("dsx self-update --help should not error");
+        let has_output = !output.stdout.is_empty() || !output.stderr.is_empty();
+        assert!(has_output, "dsx self-update --help should produce some output");
+    }
+
     /// `env_inject` に渡すコマンド文字列が空白で正しく分割されることを確認する。
     /// dsx の実際の呼び出しではなく、引数分割ロジックのみを検証する。
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use commands::{
         remove_repository, scan_directory, scan_missing_repositories, set_github_pat,
         update_ai_config, update_repository_github, update_settings,
     },
-    dsx::{dsx_check, dsx_latest_version, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
+    dsx::{dsx_check, dsx_latest_version, dsx_self_update, env_inject, repo_cleanup, repo_cleanup_preview, repo_update, sys_update},
     github::{get_check_runs, get_issues, get_pull_requests},
     repo::{
         apply_stash, delete_branches, drop_stash, fetch_all, get_branches, get_commit_graph,
@@ -64,6 +64,7 @@ pub fn run() {
             repo_cleanup,
             env_inject,
             sys_update,
+            dsx_self_update,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Arbor");

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
+import { act } from 'react';
 import ConfirmDialog from './ConfirmDialog';
 
 function renderDialog(overrides?: Partial<Parameters<typeof ConfirmDialog>[0]>) {
@@ -11,8 +12,8 @@ function renderDialog(overrides?: Partial<Parameters<typeof ConfirmDialog>[0]>) 
     onCancel: vi.fn(),
     ...overrides,
   };
-  render(<ConfirmDialog {...props} />);
-  return props;
+  const { unmount } = render(<ConfirmDialog {...props} />);
+  return { ...props, unmount };
 }
 
 describe('ConfirmDialog', () => {
@@ -48,5 +49,74 @@ describe('ConfirmDialog', () => {
     const { onCancel } = renderDialog();
     await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
     expect(onCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConfirmDialog — アクセシビリティ', () => {
+  it('role="dialog" と aria-modal="true" が設定されている', () => {
+    renderDialog();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('aria-labelledby がタイトル要素を参照している', () => {
+    renderDialog({ title: 'Test Title' });
+    const dialog = screen.getByRole('dialog');
+    const labelId = dialog.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const titleEl = document.getElementById(labelId!);
+    expect(titleEl?.textContent).toBe('Test Title');
+  });
+
+  it('マウント時に最初のボタン（Cancel）へフォーカスが当たる', () => {
+    renderDialog();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));
+  });
+
+  it('Escape キーで onCancel が呼ばれる', async () => {
+    const { onCancel } = renderDialog();
+    await userEvent.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Tab キーでフォーカスが Cancel → Confirm → Cancel と循環する', async () => {
+    renderDialog();
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    // 初期フォーカスは Cancel
+    expect(document.activeElement).toBe(cancel);
+    // Tab → Confirm へ移動
+    await userEvent.keyboard('{Tab}');
+    expect(document.activeElement).toBe(confirm);
+    // Tab → Cancel へ循環
+    await userEvent.keyboard('{Tab}');
+    expect(document.activeElement).toBe(cancel);
+  });
+
+  it('Shift+Tab キーで逆順に循環する', async () => {
+    renderDialog();
+    const confirm = screen.getByRole('button', { name: 'Confirm' });
+    // 初期フォーカスは Cancel → Shift+Tab で末尾（Confirm）へ循環
+    await userEvent.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(document.activeElement).toBe(confirm);
+  });
+
+  it('アンマウント時に呼び出し元へフォーカスが復帰する', () => {
+    // ダイアログ呼び出し前にフォーカスを当てるトリガーボタンを作成する
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open Dialog';
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = renderDialog();
+    // ダイアログが開いた後は Cancel にフォーカスが移る
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));
+
+    act(() => { unmount(); });
+    // アンマウント後はトリガーへ復帰
+    expect(document.activeElement).toBe(trigger);
+    document.body.removeChild(trigger);
   });
 });

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -69,6 +69,15 @@ describe('ConfirmDialog — アクセシビリティ', () => {
     expect(titleEl?.textContent).toBe('Test Title');
   });
 
+  it('aria-describedby がメッセージ要素を参照している', () => {
+    renderDialog({ message: 'Test message body' });
+    const dialog = screen.getByRole('dialog');
+    const descId = dialog.getAttribute('aria-describedby');
+    expect(descId).toBeTruthy();
+    const msgEl = document.getElementById(descId!);
+    expect(msgEl?.textContent).toBe('Test message body');
+  });
+
   it('マウント時に最初のボタン（Cancel）へフォーカスが当たる', () => {
     renderDialog();
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Cancel' }));

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useId, useRef } from 'react';
+
 interface ConfirmDialogProps {
   title: string;
   message: string;
@@ -15,22 +17,76 @@ export default function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    const previousFocus = document.activeElement as HTMLElement | null;
+
+    // マウント時に最初のフォーカス可能要素（Cancel）へフォーカス
+    const getFocusable = () =>
+      Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+    getFocusable()[0]?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCancel();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // アンマウント時に呼び出し元へフォーカスを復帰
+      previousFocus?.focus();
+    };
+  }, [onCancel]);
+
   return (
-    <div style={{
-      position: 'fixed', inset: 0,
-      background: 'rgba(0,0,0,.6)',
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      zIndex: 1000,
-    }}>
-      <div style={{
-        background: 'var(--bg2)',
-        border: '1px solid var(--border2)',
-        borderRadius: 'var(--r2)',
-        padding: '24px 28px',
-        maxWidth: 420,
-        width: '100%',
-      }}>
-        <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 10 }}>{title}</h2>
+    <div
+      style={{
+        position: 'fixed', inset: 0,
+        background: 'rgba(0,0,0,.6)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 1000,
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        style={{
+          background: 'var(--bg2)',
+          border: '1px solid var(--border2)',
+          borderRadius: 'var(--r2)',
+          padding: '24px 28px',
+          maxWidth: 420,
+          width: '100%',
+        }}
+      >
+        <h2 id={titleId} style={{ fontSize: 15, fontWeight: 600, marginBottom: 10 }}>{title}</h2>
         <p style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.65, marginBottom: 20, whiteSpace: 'pre-wrap' }}>
           {message}
         </p>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -19,6 +19,7 @@ export default function ConfirmDialog({
 }: ConfirmDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
+  const messageId = useId();
   const onCancelRef = useRef(onCancel);
 
   // 最新の onCancel を ref に同期（deps なし → 毎レンダー後に実行）
@@ -83,6 +84,7 @@ export default function ConfirmDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
+        aria-describedby={messageId}
         style={{
           background: 'var(--bg2)',
           border: '1px solid var(--border2)',
@@ -93,7 +95,7 @@ export default function ConfirmDialog({
         }}
       >
         <h2 id={titleId} style={{ fontSize: 15, fontWeight: 600, marginBottom: 10 }}>{title}</h2>
-        <p style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.65, marginBottom: 20, whiteSpace: 'pre-wrap' }}>
+        <p id={messageId} style={{ fontSize: 13, color: 'var(--text2)', lineHeight: 1.65, marginBottom: 20, whiteSpace: 'pre-wrap' }}>
           {message}
         </p>
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -19,11 +19,16 @@ export default function ConfirmDialog({
 }: ConfirmDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null);
   const titleId = useId();
+  const onCancelRef = useRef(onCancel);
+
+  // 最新の onCancel を ref に同期（deps なし → 毎レンダー後に実行）
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  });
 
   useEffect(() => {
     const previousFocus = document.activeElement as HTMLElement | null;
 
-    // マウント時に最初のフォーカス可能要素（Cancel）へフォーカス
     const getFocusable = () =>
       Array.from(
         dialogRef.current?.querySelectorAll<HTMLElement>(
@@ -34,7 +39,7 @@ export default function ConfirmDialog({
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onCancel();
+        onCancelRef.current();
         return;
       }
       if (e.key !== 'Tab') return;
@@ -58,10 +63,11 @@ export default function ConfirmDialog({
     document.addEventListener('keydown', handleKeyDown);
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      // アンマウント時に呼び出し元へフォーカスを復帰
+      // アンマウント時のみ呼び出し元へフォーカスを復帰
       previousFocus?.focus();
     };
-  }, [onCancel]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act } from 'react';
+import Sidebar from './Sidebar';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+
+function makeRepo(path: string, name: string) {
+  return {
+    path, name,
+    current_branch: 'main',
+    ahead: 0, behind: 0,
+    modified_count: 0, untracked_count: 0, stash_count: 0,
+    github_owner: null, github_repo: null, last_fetched_at: null,
+  };
+}
+
+beforeEach(() => {
+  act(() => {
+    useRepoStore.setState({ repos: [], selectedRepo: null });
+    useUiStore.setState({ activeView: 'overview', navigate: vi.fn() });
+  });
+});
+
+describe('Sidebar — ナビゲーション ARIA', () => {
+  it('<nav> に aria-label="ナビゲーション" が付与されている', () => {
+    render(<Sidebar />);
+    expect(screen.getByRole('navigation', { name: 'ナビゲーション' })).toBeInTheDocument();
+  });
+
+  it('アクティブなビューのボタンに aria-current="page" が付与されている', () => {
+    act(() => { useUiStore.setState({ activeView: 'branches' }); });
+    render(<Sidebar />);
+    const activeBtn = screen.getByRole('button', { name: 'Branches' });
+    expect(activeBtn).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('非アクティブなビューのボタンには aria-current が付与されない', () => {
+    act(() => { useUiStore.setState({ activeView: 'overview' }); });
+    render(<Sidebar />);
+    const inactiveBtn = screen.getByRole('button', { name: 'Branches' });
+    expect(inactiveBtn).not.toHaveAttribute('aria-current');
+  });
+});
+
+describe('Sidebar — リポジトリ一覧 ARIA', () => {
+  it('リポジトリ一覧 region に aria-label が付与されている', () => {
+    render(<Sidebar />);
+    expect(screen.getByRole('region', { name: 'リポジトリ一覧' })).toBeInTheDocument();
+  });
+
+  it('選択済みリポジトリのボタンに aria-pressed="true" が付与されている', () => {
+    const repo = makeRepo('/repo/a', 'my-repo');
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: repo }); });
+    render(<Sidebar />);
+    const btn = screen.getByRole('button', { name: 'my-repo' });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('未選択リポジトリのボタンに aria-pressed="false" が付与されている', () => {
+    const repo = makeRepo('/repo/a', 'my-repo');
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    render(<Sidebar />);
+    const btn = screen.getByRole('button', { name: 'my-repo' });
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('リポジトリボタンクリックで selectRepo が呼ばれる', async () => {
+    const mockSelectRepo = vi.fn();
+    const repo = makeRepo('/repo/a', 'my-repo');
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null, selectRepo: mockSelectRepo }); });
+    render(<Sidebar />);
+    await userEvent.click(screen.getByRole('button', { name: 'my-repo' }));
+    expect(mockSelectRepo).toHaveBeenCalledWith(repo);
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -49,16 +49,21 @@ export default function Sidebar() {
       </div>
 
       {/* Repository list — flex:1 + overflow-y:auto でスクロール可能にする (#44) */}
-      <div style={{
-        padding: '8px',
-        borderBottom: '1px solid var(--border)',
-        flex: 1,
-        minHeight: 0,
-        overflowY: 'auto',
-      }}>
+      <div
+        role="region"
+        aria-label="リポジトリ一覧"
+        style={{
+          padding: '8px',
+          borderBottom: '1px solid var(--border)',
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+        }}
+      >
         {repos.map((repo) => (
           <button
             key={repo.path}
+            aria-pressed={selectedRepo?.path === repo.path}
             onClick={() => selectRepo(repo)}
             style={{
               display: 'flex',
@@ -113,10 +118,12 @@ export default function Sidebar() {
       </div>
 
       {/* Navigation — 固定高さ（flex:1 は repo list 側に移動） */}
-      <nav style={{ padding: '8px' }}>
+      <nav aria-label="ナビゲーション" style={{ padding: '8px' }}>
         {NAV_ITEMS.map((item) => (
           <button
             key={item.id}
+            aria-label={item.label}
+            aria-current={activeView === item.id ? 'page' : undefined}
             onClick={() => navigate(item.id)}
             style={{
               display: 'flex',

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -144,6 +144,9 @@ export const envInject = (repoPath: string, cmd: string) =>
 export const sysUpdate = () =>
   tauriInvoke<DsxOutput>('sys_update');
 
+export const dsxSelfUpdate = () =>
+  tauriInvoke<DsxOutput>('dsx_self_update');
+
 // ─── AI / Ollama ─────────────────────────────────────────────────────────────
 
 /** Returns true if Ollama is running and reachable. Never throws; returns false on failure. */

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -93,8 +93,8 @@ describe('Settings — dsx CLI section', () => {
 
   it('dsx が利用可能な場合に Update ボタンを表示する', async () => {
     renderSettings();
-    await screen.findByRole('button', { name: 'Update' });
-    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+    await screen.findByRole('button', { name: 'Sys Update' });
+    expect(screen.getByRole('button', { name: 'Sys Update' })).toBeInTheDocument();
   });
 
   it('dsx が利用不可の場合に Update ボタンを表示しない', async () => {
@@ -102,20 +102,38 @@ describe('Settings — dsx CLI section', () => {
     renderSettings();
     // インストール案内テキストが出るまで待つ
     await screen.findByText(/dsx が見つかりません/);
-    expect(screen.queryByRole('button', { name: 'Update' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sys Update' })).not.toBeInTheDocument();
   });
 
-  it('Update ボタンをクリックすると sysUpdate が呼ばれる', async () => {
+  it('Update ボタンをクリックすると確認ダイアログが表示される', async () => {
     renderSettings();
-    const btn = await screen.findByRole('button', { name: 'Update' });
+    const btn = await screen.findByRole('button', { name: 'Sys Update' });
     await userEvent.click(btn);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(mockSysUpdate).not.toHaveBeenCalled();
+  });
+
+  it('確認ダイアログで「実行」をクリックすると sysUpdate が呼ばれる', async () => {
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'Sys Update' });
+    await userEvent.click(btn);
+    await userEvent.click(screen.getByRole('button', { name: '実行' }));
     expect(mockSysUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('確認ダイアログでキャンセルすると sysUpdate が呼ばれない', async () => {
+    renderSettings();
+    const btn = await screen.findByRole('button', { name: 'Sys Update' });
+    await userEvent.click(btn);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(mockSysUpdate).not.toHaveBeenCalled();
   });
 
   it('sysUpdate 完了後に dsxCheck を再呼び出しする', async () => {
     renderSettings();
-    const btn = await screen.findByRole('button', { name: 'Update' });
+    const btn = await screen.findByRole('button', { name: 'Sys Update' });
     await userEvent.click(btn);
+    await userEvent.click(screen.getByRole('button', { name: '実行' }));
     await waitFor(() => {
       // 初回 mount + update 後の再チェックで計 2 回呼ばれる
       expect(mockDsxCheck).toHaveBeenCalledTimes(2);
@@ -125,8 +143,9 @@ describe('Settings — dsx CLI section', () => {
   it('sysUpdate が失敗した場合にエラートーストを表示する', async () => {
     mockSysUpdate.mockRejectedValue(new Error('network error') as never);
     renderSettings(true);
-    const btn = await screen.findByRole('button', { name: 'Update' });
+    const btn = await screen.findByRole('button', { name: 'Sys Update' });
     await userEvent.click(btn);
+    await userEvent.click(screen.getByRole('button', { name: '実行' }));
     // Toast に error メッセージが表示される（String(Error) → "Error: network error"）
     await screen.findByText('Error: network error');
   });

--- a/src/views/Settings.test.tsx
+++ b/src/views/Settings.test.tsx
@@ -172,12 +172,33 @@ describe('Settings — dsx CLI section', () => {
     await screen.findByText(/最新版です/);
   });
 
-  it('新バージョンがあるとき「利用可能」を表示する', async () => {
+  it('新バージョンがあるとき「利用可能」と「Self Update」ボタンを表示する', async () => {
     mockDsxLatestVersion.mockResolvedValue('v0.9.9' as never);
     renderSettings();
     const btn = await screen.findByRole('button', { name: 'バージョン確認' });
     await userEvent.click(btn);
     await screen.findByText(/v0\.9\.9 が利用可能/);
+    expect(screen.getByRole('button', { name: 'Self Update' })).toBeInTheDocument();
+  });
+
+  it('「Self Update」クリックで確認ダイアログが表示される', async () => {
+    const mockDsxSelfUpdate = vi.spyOn(invoke, 'dsxSelfUpdate').mockResolvedValue({} as never);
+    mockDsxLatestVersion.mockResolvedValue('v0.9.9' as never);
+    renderSettings();
+    await userEvent.click(await screen.findByRole('button', { name: 'バージョン確認' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Self Update' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(mockDsxSelfUpdate).not.toHaveBeenCalled();
+  });
+
+  it('「Self Update」確認後に dsxSelfUpdate が呼ばれる', async () => {
+    const mockDsxSelfUpdate = vi.spyOn(invoke, 'dsxSelfUpdate').mockResolvedValue({} as never);
+    mockDsxLatestVersion.mockResolvedValue('v0.9.9' as never);
+    renderSettings();
+    await userEvent.click(await screen.findByRole('button', { name: 'バージョン確認' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Self Update' }));
+    await userEvent.click(screen.getByRole('button', { name: '実行' }));
+    expect(mockDsxSelfUpdate).toHaveBeenCalledTimes(1);
   });
 
   it('取得失敗のとき「取得できませんでした」を表示する', async () => {

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -4,7 +4,7 @@ import { useUiStore } from '../stores/uiStore';
 import { useRepoStore } from '../stores/repoStore';
 import AppBar, { AppBtn } from '../components/AppBar';
 import ConfirmDialog from '../components/ConfirmDialog';
-import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, scanMissingRepositories, dsxCheck, dsxLatestVersion, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate, updateAiConfig, testAiConnection } from '../lib/invoke';
+import { getConfig, addRepository, removeRepository, updateRepositoryGithub, detectGithubRemote, scanDirectory, scanMissingRepositories, dsxCheck, dsxLatestVersion, dsxSelfUpdate, hasGithubPat, setGithubPat, deleteGithubPat, sysUpdate, updateAiConfig, testAiConnection } from '../lib/invoke';
 import { open } from '@tauri-apps/plugin-dialog';
 import type { AppConfig, DsxStatus, RepoConfig } from '../types';
 
@@ -19,6 +19,8 @@ export default function Settings() {
   const [patLoading, setPatLoading] = useState(false);
   const [sysUpdating, setSysUpdating] = useState(false);
   const [showSysUpdateConfirm, setShowSysUpdateConfirm] = useState(false);
+  const [selfUpdating, setSelfUpdating] = useState(false);
+  const [showSelfUpdateConfirm, setShowSelfUpdateConfirm] = useState(false);
   const [dsxUpdateState, setDsxUpdateState] = useState<'idle' | 'checking' | 'done' | 'error'>('idle');
   const [latestDsxVersion, setLatestDsxVersion] = useState<string | null>(null);
   const [scanResults, setScanResults] = useState<string[] | null>(null);
@@ -195,6 +197,24 @@ export default function Settings() {
     }
   };
 
+  const handleDsxSelfUpdate = async () => {
+    setSelfUpdating(true);
+    setDsxRunning(true);
+    try {
+      await dsxSelfUpdate();
+      addToast('dsx self-update 完了', 'success');
+      const status = await dsxCheck();
+      setDsxStatus(status);
+      setDsxUpdateState('idle');
+      setLatestDsxVersion(null);
+    } catch (e) {
+      addToast(String(e), 'error');
+    } finally {
+      setSelfUpdating(false);
+      setDsxRunning(false);
+    }
+  };
+
   const handleSaveAiConfig = async () => {
     const timeoutNum = parseInt(aiForm.timeoutSecs, 10);
     if (isNaN(timeoutNum) || timeoutNum < 1 || timeoutNum > 300) {
@@ -335,7 +355,12 @@ export default function Settings() {
                   </AppBtn>
                 </div>
                 {dsxUpdateState === 'done' && (
-                  <DsxUpdateResult current={dsxStatus.version ?? ''} latest={latestDsxVersion} />
+                  <DsxUpdateResult
+                    current={dsxStatus.version ?? ''}
+                    latest={latestDsxVersion}
+                    selfUpdating={selfUpdating}
+                    onSelfUpdate={() => setShowSelfUpdateConfirm(true)}
+                  />
                 )}
                 {dsxUpdateState === 'error' && (
                   <div style={{ fontSize: 11, color: 'var(--text3)' }}>
@@ -697,6 +722,16 @@ export default function Settings() {
 
       </div>
 
+      {showSelfUpdateConfirm && (
+        <ConfirmDialog
+          title="dsx self-update を実行しますか？"
+          message={'dsx CLI 自体を最新版に更新します。\n完了まで少し時間がかかることがあります。'}
+          confirmLabel="実行"
+          onConfirm={() => { setShowSelfUpdateConfirm(false); handleDsxSelfUpdate(); }}
+          onCancel={() => setShowSelfUpdateConfirm(false)}
+        />
+      )}
+
       {showSysUpdateConfirm && (
         <ConfirmDialog
           title="dsx sys update — システム全体の更新"
@@ -832,7 +867,17 @@ export function compareSemverLike(a: string, b: string): number | null {
   return 0;
 }
 
-function DsxUpdateResult({ current, latest }: { current: string; latest: string | null }) {
+function DsxUpdateResult({
+  current,
+  latest,
+  selfUpdating,
+  onSelfUpdate,
+}: {
+  current: string;
+  latest: string | null;
+  selfUpdating: boolean;
+  onSelfUpdate: () => void;
+}) {
   if (!latest) {
     return (
       <div style={{ fontSize: 11, color: 'var(--text3)' }}>
@@ -853,11 +898,13 @@ function DsxUpdateResult({ current, latest }: { current: string; latest: string 
       ✓ 最新版です（{latest}）
     </div>
   ) : (
-    <div style={{ fontSize: 11, color: 'var(--amber)', lineHeight: 1.6 }}>
-      ↑ {latest} が利用可能です。以下のコマンドで更新してください:<br />
-      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--indigo-l)' }}>
-        go install github.com/scottlz0310/dsx@latest
-      </span>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <div style={{ fontSize: 11, color: 'var(--amber)' }}>
+        ↑ {latest} が利用可能です
+      </div>
+      <AppBtn onClick={onSelfUpdate} disabled={selfUpdating}>
+        {selfUpdating ? 'Updating…' : 'Self Update'}
+      </AppBtn>
     </div>
   );
 }

--- a/src/views/Settings.tsx
+++ b/src/views/Settings.tsx
@@ -18,6 +18,7 @@ export default function Settings() {
   const [patInput, setPatInput]   = useState('');
   const [patLoading, setPatLoading] = useState(false);
   const [sysUpdating, setSysUpdating] = useState(false);
+  const [showSysUpdateConfirm, setShowSysUpdateConfirm] = useState(false);
   const [dsxUpdateState, setDsxUpdateState] = useState<'idle' | 'checking' | 'done' | 'error'>('idle');
   const [latestDsxVersion, setLatestDsxVersion] = useState<string | null>(null);
   const [scanResults, setScanResults] = useState<string[] | null>(null);
@@ -326,10 +327,11 @@ export default function Settings() {
                     {dsxUpdateState === 'checking' ? '確認中…' : 'バージョン確認'}
                   </AppBtn>
                   <AppBtn
-                    onClick={handleSysUpdate}
+                    onClick={() => setShowSysUpdateConfirm(true)}
                     disabled={sysUpdating}
+                    title="dsx sys update — dsx が管理するツール群を一括更新"
                   >
-                    {sysUpdating ? 'Updating…' : 'Update'}
+                    {sysUpdating ? 'Updating…' : 'Sys Update'}
                   </AppBtn>
                 </div>
                 {dsxUpdateState === 'done' && (
@@ -694,6 +696,16 @@ export default function Settings() {
         </section>
 
       </div>
+
+      {showSysUpdateConfirm && (
+        <ConfirmDialog
+          title="dsx sys update — システム全体の更新"
+          message={'dsx が管理するすべてのツールを最新版に更新します（dsx CLI 自体の更新ではありません）。\n完了まで数分かかることがあります。'}
+          confirmLabel="実行"
+          onConfirm={() => { setShowSysUpdateConfirm(false); handleSysUpdate(); }}
+          onCancel={() => setShowSysUpdateConfirm(false)}
+        />
+      )}
 
       {confirmDeregister && (
         <ConfirmDialog


### PR DESCRIPTION
## Summary

### P4-10: アクセシビリティ改善 (Closes #107)

- `ConfirmDialog`: `role="dialog"` / `aria-modal="true"` / `aria-labelledby` / `aria-describedby` 追加
  - フォーカストラップ（Tab/Shift+Tab 循環）・Escape キー対応
  - マウント時に Cancel ボタンへ自動フォーカス
  - アンマウント時のみ呼び出し元へフォーカス復帰（`onCancelRef` + deps `[]` で inline handler による再実行を回避）
- `Sidebar`: リポジトリ一覧に `role="region"` + `aria-label="リポジトリ一覧"`、リポジトリボタンに `aria-pressed`、nav に `aria-label="ナビゲーション"`、nav ボタンに `aria-current="page"` と `aria-label` を追加
- フロントエンドテスト 15 件追加（ConfirmDialog a11y 8件・Sidebar a11y 7件）

### P4-04 追加修正: dsx Self Update ボタン追加・Sys Update ラベル明確化（実機テスト由来）

- バージョン確認で新版検出時に「Self Update」ボタンを表示し、ConfirmDialog 経由で `dsx self-update` を実行（dsx CLI 自体の更新）
- `dsx_self_update` Tauri コマンド追加（`src-tauri/src/commands/dsx.rs`）
- 既存「Update」ボタンを「Sys Update」に改名 + tooltip 追加（dsx 管理ツール一括更新であることを明示、dsx CLI の更新ではない）
- 「Sys Update」クリック時に ConfirmDialog を追加し誤実行を防止
- Settings テスト 5 件追加

## Test plan

- [x] `pnpm test` — 143 件全パス
- [x] `cargo test` — 77 件全パス
- [x] 実機テスト: ConfirmDialog の Tab/Shift+Tab フォーカス循環・Escape・フォーカス復帰を確認
- [x] 実機テスト: Sidebar の ARIA 属性を確認
- [ ] 最新コミットの CI green を確認してから merge

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)