### PR TITLE
feat(ai): AI Assistant タブを新規追加 (#132)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Graph from './views/Graph';
 import PullRequests from './views/PullRequests';
 import Cleanup from './views/Cleanup';
 import Stash from './views/Stash';
+import AiAssistant from './views/AiAssistant';
 import Settings from './views/Settings';
 import { useRepoStore } from './stores/repoStore';
 import { useUiStore } from './stores/uiStore';
@@ -90,6 +91,9 @@ export default function App() {
         )}
         {activeView === 'stash' && (
           <ErrorBoundary key="stash" viewName="Stash Manager"><Stash /></ErrorBoundary>
+        )}
+        {activeView === 'ai' && (
+          <ErrorBoundary key="ai" viewName="AI Assistant"><AiAssistant /></ErrorBoundary>
         )}
         {activeView === 'settings' && (
           <ErrorBoundary key="settings" viewName="Settings"><Settings /></ErrorBoundary>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -19,6 +19,7 @@ const VIEW_COMMANDS: { id: ViewId; icon: string; label: string }[] = [
   { id: 'prs',       icon: '⇄', label: 'PR / Issues' },
   { id: 'cleanup',   icon: '✦', label: 'Cleanup' },
   { id: 'stash',     icon: '⊟', label: 'Stash' },
+  { id: 'ai',        icon: '⚛', label: 'AI Assistant' },
   { id: 'settings',  icon: '⚙', label: 'Settings' },
 ];
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS: { id: ViewId; icon: string; label: string }[] = [
   { id: 'prs',       icon: '⇄', label: 'PR / Issues' },
   { id: 'cleanup',   icon: '✦', label: 'Cleanup' },
   { id: 'stash',     icon: '⊟', label: 'Stash' },
+  { id: 'ai',        icon: '⚛', label: 'AI Assistant' },
   { id: 'settings',  icon: '⚙', label: 'Settings' },
 ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -153,7 +153,7 @@ export interface StashInfo {
   commit_id: string;
 }
 
-export type ViewId = 'overview' | 'branches' | 'graph' | 'prs' | 'cleanup' | 'stash' | 'settings';
+export type ViewId = 'overview' | 'branches' | 'graph' | 'prs' | 'cleanup' | 'stash' | 'ai' | 'settings';
 
 export type InsightType = 'explain' | 'prioritize' | 'risk';
 export type InsightSource = 'rule' | 'ai';

--- a/src/views/AiAssistant.test.tsx
+++ b/src/views/AiAssistant.test.tsx
@@ -259,6 +259,36 @@ describe('AiAssistant — AI disabled 時の挙動', () => {
   });
 });
 
+describe('AiAssistant — loading 状態のリセット', () => {
+  it('mid-fetch 中に repos が空になっても insightLoading が残らない', async () => {
+    // 解決可能な fetch を pending のまま保持して mid-fetch 状態を再現する
+    let resolveFetch!: (v: { insights: Insight[]; source: 'rule' | 'ai'; ollamaOffline: boolean }) => void;
+    vi.mocked(aiService.fetchInsights).mockReturnValue(
+      new Promise((res) => { resolveFetch = res; }),
+    );
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    // loading 表示が出るまで待つ（aiConfig 読み込み完了後）
+    await waitFor(() => {
+      expect(screen.getByText('分析中…')).toBeTruthy();
+    });
+    // repos を空にする → cancelled guard で finally がスキップされるが、
+    // 新しい effect 側が setInsightLoading(false) を明示実行するので loading は残らない
+    act(() => {
+      useRepoStore.setState({ repos: [], selectedRepo: null });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('分析中…')).toBeNull();
+    });
+    // pending fetch を後から解決しても loading は復活しない
+    act(() => resolveFetch({ insights: [], source: 'rule', ollamaOffline: false }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText('分析中…')).toBeNull();
+  });
+});
+
 describe('AiAssistant — イベント購読', () => {
   it('ai_insights_loading で "AI 分析中…" バッジが表示される', async () => {
     act(() => {

--- a/src/views/AiAssistant.test.tsx
+++ b/src/views/AiAssistant.test.tsx
@@ -23,9 +23,20 @@ vi.mock('../lib/aiService', async () => {
 });
 
 // @tauri-apps/api/event の listen をスタブ化（jsdom では IPC 利用不可）
+// 各 event 名に対する handler を捕捉して、テストから手動で payload を流せるようにする
+const eventHandlers = new Map<string, (event: { payload: unknown }) => void>();
 vi.mock('@tauri-apps/api/event', () => ({
-  listen: vi.fn(() => Promise.resolve(() => {})),
+  listen: vi.fn((event: string, handler: (event: { payload: unknown }) => void) => {
+    eventHandlers.set(event, handler);
+    return Promise.resolve(() => eventHandlers.delete(event));
+  }),
 }));
+
+function emitEvent(name: string, payload: unknown) {
+  const handler = eventHandlers.get(name);
+  if (!handler) throw new Error(`No listener registered for "${name}"`);
+  handler({ payload });
+}
 
 function makeRepo(overrides: Partial<RepoInfo> = {}): RepoInfo {
   return {
@@ -56,6 +67,7 @@ const NO_INSIGHTS: Insight[] = [];
 
 beforeEach(() => {
   vi.clearAllMocks();
+  eventHandlers.clear();
   act(() => {
     useRepoStore.setState({ repos: [], selectedRepo: null });
     useUiStore.setState({ toasts: [], dsxProgress: [], dsxRunning: false, activeView: 'ai' });
@@ -202,6 +214,97 @@ describe('AiAssistant — Insight 表示', () => {
     render(<AiAssistant />);
     await waitFor(() => {
       expect(screen.getByText('Ollama が未起動のため AI 分析を実行できません')).toBeTruthy();
+    });
+  });
+
+  it('同名 repo の区別のため selected セクションに path が補助表示される', async () => {
+    const repo = makeRepo({ path: '/work/clone-a/alpha', name: 'alpha' });
+    act(() => {
+      useRepoStore.setState({ repos: [repo], selectedRepo: repo });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getAllByText('/work/clone-a/alpha').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('RepoInsightGroup に repo path が表示される（同名 repo 区別）', async () => {
+    const repos = [
+      makeRepo({ path: '/work/clone-a/alpha', name: 'alpha' }),
+      makeRepo({ path: '/work/clone-b/alpha', name: 'alpha' }),
+    ];
+    act(() => {
+      useRepoStore.setState({ repos, selectedRepo: repos[0] });
+    });
+    render(<AiAssistant />);
+    // clone-a path は selected セクション + group の両方に出るため getAllByText
+    await waitFor(() => {
+      expect(screen.getAllByText('/work/clone-a/alpha').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('/work/clone-b/alpha').length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe('AiAssistant — AI disabled 時の挙動', () => {
+  it('AI disabled 時は fetchInsights を呼ばず "Settings で有効化" 表示', async () => {
+    vi.mocked(invoke.getConfig).mockResolvedValue(makeConfig(false));
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Settings で有効化してください/).length).toBeGreaterThan(0);
+    });
+    expect(aiService.fetchInsights).not.toHaveBeenCalled();
+  });
+});
+
+describe('AiAssistant — イベント購読', () => {
+  it('ai_insights_loading で "AI 分析中…" バッジが表示される', async () => {
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(eventHandlers.has('ai_insights_loading')).toBe(true);
+    });
+    act(() => emitEvent('ai_insights_loading', undefined));
+    await waitFor(() => {
+      expect(screen.getByText(/AI 分析中…/)).toBeTruthy();
+    });
+  });
+
+  it('ai_insights_updated で AI insight に差し替わる', async () => {
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(eventHandlers.has('ai_insights_updated')).toBe(true);
+    });
+    const ai: AiInsight[] = [
+      { repo_name: 'alpha', kind: 'risk', message: 'event-pushed-risk', priority: 3 },
+    ];
+    act(() => emitEvent('ai_insights_updated', ai));
+    await waitFor(() => {
+      expect(screen.getByText('event-pushed-risk')).toBeTruthy();
+    });
+  });
+
+  it('ai_insights_failed で "AI 失敗" バッジが表示される', async () => {
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    // SectionHeader の aiFailed バッジは !loading 条件下でのみ表示されるので、
+    // 初回 fetchInsights の loading が解けるまで待ってから emit する
+    await waitFor(() => {
+      expect(aiService.fetchInsights).toHaveBeenCalled();
+      expect(screen.getByText(/特筆すべき項目はありません/)).toBeTruthy();
+    });
+    act(() => emitEvent('ai_insights_failed', undefined));
+    await waitFor(() => {
+      expect(screen.getByText(/AI 失敗/)).toBeTruthy();
     });
   });
 });

--- a/src/views/AiAssistant.test.tsx
+++ b/src/views/AiAssistant.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act } from 'react';
+import AiAssistant from './AiAssistant';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import * as invoke from '../lib/invoke';
+import * as aiService from '../lib/aiService';
+import type { AiInsight, AppConfig, Insight, RepoInfo } from '../types';
+
+vi.mock('../lib/invoke', () => ({
+  getAiInsights:    vi.fn(),
+  getConfig:        vi.fn(),
+  ollamaAvailable:  vi.fn(),
+}));
+
+vi.mock('../lib/aiService', async () => {
+  const actual = await vi.importActual<typeof import('../lib/aiService')>('../lib/aiService');
+  return {
+    ...actual,
+    fetchInsights: vi.fn(),
+  };
+});
+
+// @tauri-apps/api/event の listen をスタブ化（jsdom では IPC 利用不可）
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+function makeRepo(overrides: Partial<RepoInfo> = {}): RepoInfo {
+  return {
+    path: '/repo/alpha',
+    name: 'alpha',
+    current_branch: 'main',
+    ahead: 0,
+    behind: 0,
+    modified_count: 0,
+    untracked_count: 0,
+    stash_count: 0,
+    github_owner: null,
+    github_repo: null,
+    last_fetched_at: null,
+    ...overrides,
+  };
+}
+
+function makeConfig(enabled = true): AppConfig {
+  return {
+    settings: { stale_threshold_days: 14, fetch_on_startup: false, github_keychain_key: 'k' },
+    ai:       { provider: 'ollama', ollama_url: 'http://localhost:11434', model: 'qwen3.5:latest', enabled, timeout_secs: 30 },
+    repositories: [],
+  };
+}
+
+const NO_INSIGHTS: Insight[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  act(() => {
+    useRepoStore.setState({ repos: [], selectedRepo: null });
+    useUiStore.setState({ toasts: [], dsxProgress: [], dsxRunning: false, activeView: 'ai' });
+  });
+  vi.mocked(invoke.getConfig).mockResolvedValue(makeConfig(true));
+  vi.mocked(invoke.ollamaAvailable).mockResolvedValue(true);
+  vi.mocked(aiService.fetchInsights).mockResolvedValue({
+    insights: NO_INSIGHTS, source: 'rule', ollamaOffline: false,
+  });
+});
+
+describe('AiAssistant — 接続ステータス', () => {
+  it('Ollama 接続成功時に "接続済み" を表示する', async () => {
+    vi.mocked(invoke.ollamaAvailable).mockResolvedValue(true);
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getByText('Ollama に接続済み')).toBeTruthy();
+    });
+  });
+
+  it('Ollama 接続失敗時に "接続できません" を表示する', async () => {
+    vi.mocked(invoke.ollamaAvailable).mockResolvedValue(false);
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getByText('Ollama に接続できません')).toBeTruthy();
+    });
+  });
+
+  it('AI 無効化時は接続ステータスより先に "無効化されています" を表示する', async () => {
+    vi.mocked(invoke.getConfig).mockResolvedValue(makeConfig(false));
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getByText('AI Insight は無効化されています')).toBeTruthy();
+    });
+  });
+
+  it('使用モデル名 / プロバイダが表示される', async () => {
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getByText('qwen3.5:latest')).toBeTruthy();
+      expect(screen.getByText('ollama')).toBeTruthy();
+    });
+  });
+
+  it('接続テストボタンで ollamaAvailable が再実行される', async () => {
+    render(<AiAssistant />);
+    await waitFor(() => expect(invoke.ollamaAvailable).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: '接続テスト' }));
+    await waitFor(() => expect(invoke.ollamaAvailable).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe('AiAssistant — 再分析ボタン', () => {
+  it('リポジトリ未登録時は disabled', async () => {
+    render(<AiAssistant />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /再分析/ }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+  });
+
+  it('接続失敗時は disabled', async () => {
+    vi.mocked(invoke.ollamaAvailable).mockResolvedValue(false);
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /再分析/ }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+  });
+
+  it('AI 無効時は disabled', async () => {
+    vi.mocked(invoke.getConfig).mockResolvedValue(makeConfig(false));
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /再分析/ }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+  });
+
+  it('正常時にクリックすると getAiInsights が呼ばれる', async () => {
+    const mockInsights: AiInsight[] = [
+      { repo_name: 'alpha', kind: 'risk', message: '危険なブランチ', priority: 3 },
+    ];
+    vi.mocked(invoke.getAiInsights).mockResolvedValue(mockInsights);
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /再分析/ }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+    fireEvent.click(screen.getByRole('button', { name: /再分析/ }));
+    await waitFor(() => {
+      expect(invoke.getAiInsights).toHaveBeenCalledWith([makeRepo()]);
+    });
+  });
+});
+
+describe('AiAssistant — Insight 表示', () => {
+  it('リポジトリが選択されていなければプロンプトを表示', async () => {
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getByText('リポジトリを選択してください')).toBeTruthy();
+    });
+  });
+
+  it('選択リポジトリの insights だけがメインセクションに表示される', async () => {
+    const repos = [makeRepo(), makeRepo({ path: '/repo/beta', name: 'beta' })];
+    const insights: Insight[] = [
+      { type: 'risk',    target: 'alpha', priority: 'high',   reason: 'alpha-risk',    source: 'ai' },
+      { type: 'explain', target: 'beta',  priority: 'low',    reason: 'beta-explain',  source: 'ai' },
+    ];
+    vi.mocked(aiService.fetchInsights).mockResolvedValue({
+      insights, source: 'ai', ollamaOffline: false,
+    });
+    act(() => {
+      useRepoStore.setState({ repos, selectedRepo: repos[0] });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      // 選択中の reason が反映されるまで待つ
+      expect(screen.getAllByText('alpha-risk').length).toBeGreaterThan(0);
+    });
+    // 選択中リポジトリヘッダ（getAllByText で重複表示にも耐える）
+    expect(screen.getAllByText(/AI INSIGHTS — alpha/).length).toBeGreaterThan(0);
+    // 他リポジトリの reason はリポジトリ別グループに表示される
+    expect(screen.getAllByText('beta-explain').length).toBeGreaterThan(0);
+  });
+
+  it('Ollama オフライン時に専用メッセージを表示', async () => {
+    vi.mocked(aiService.fetchInsights).mockResolvedValue({
+      insights: [], source: 'rule', ollamaOffline: true,
+    });
+    act(() => {
+      useRepoStore.setState({ repos: [makeRepo()], selectedRepo: makeRepo() });
+    });
+    render(<AiAssistant />);
+    await waitFor(() => {
+      expect(screen.getByText('Ollama が未起動のため AI 分析を実行できません')).toBeTruthy();
+    });
+  });
+});

--- a/src/views/AiAssistant.tsx
+++ b/src/views/AiAssistant.tsx
@@ -63,15 +63,20 @@ export default function AiAssistant() {
   // - aiConfig 未ロード時は待機
   // - AI 無効化時は取得自体を抑止し、UI 側で「Settings で有効化してください」を促す
   // - cancelled guard で repos 連続更新時の race を防ぐ
+  // - mid-fetch 中に non-active 分岐へ遷移した場合に loading が残らないよう全分岐で明示リセット
   useEffect(() => {
     if (repos.length === 0) {
       setInsights([]);
       setOllamaOffline(false);
       setAiBgRunning(false);
       setAiFailed(false);
+      setInsightLoading(false);
       return;
     }
-    if (aiConfig === null) return; // 初期ロード完了待ち
+    if (aiConfig === null) {
+      setInsightLoading(false);
+      return; // 初期ロード完了待ち
+    }
     if (!aiConfig.enabled) {
       setInsights([]);
       setOllamaOffline(false);

--- a/src/views/AiAssistant.tsx
+++ b/src/views/AiAssistant.tsx
@@ -38,6 +38,7 @@ export default function AiAssistant() {
 
   // 接続テスト：Settings の testAiConnection はフォーム入力中の URL を検証するためのもの。
   // ここでは保存済み config を使って稼働確認したいので ollamaAvailable を使う。
+  // ボタン経由の明示的トリガなので cancelled guard は不要（初回 mount 時は useEffect 側で wrap）。
   const checkConnection = () => {
     setConnection('checking');
     ollamaAvailable()
@@ -51,11 +52,17 @@ export default function AiAssistant() {
     getConfig()
       .then((cfg) => { if (!cancelled) setAiConfig(cfg.ai); })
       .catch(() => {});
-    checkConnection();
+    setConnection('checking');
+    ollamaAvailable()
+      .then((ok) => { if (!cancelled) setConnection(ok ? 'connected' : 'disconnected'); })
+      .catch(() => { if (!cancelled) setConnection('disconnected'); });
     return () => { cancelled = true; };
   }, []);
 
-  // Insight 取得（repos 変更時に再実行）
+  // Insight 取得（repos / aiConfig 変更時に再実行）
+  // - aiConfig 未ロード時は待機
+  // - AI 無効化時は取得自体を抑止し、UI 側で「Settings で有効化してください」を促す
+  // - cancelled guard で repos 連続更新時の race を防ぐ
   useEffect(() => {
     if (repos.length === 0) {
       setInsights([]);
@@ -64,16 +71,28 @@ export default function AiAssistant() {
       setAiFailed(false);
       return;
     }
+    if (aiConfig === null) return; // 初期ロード完了待ち
+    if (!aiConfig.enabled) {
+      setInsights([]);
+      setOllamaOffline(false);
+      setAiBgRunning(false);
+      setAiFailed(false);
+      setInsightLoading(false);
+      return;
+    }
+    let cancelled = false;
     setInsightLoading(true);
     setAiFailed(false);
     fetchInsights(repos, {}, 14)
       .then(({ insights: ins, source: s, ollamaOffline: offline }) => {
+        if (cancelled) return;
         setInsights(ins);
         setSource(s);
         setOllamaOffline(offline);
       })
-      .finally(() => setInsightLoading(false));
-  }, [repos]);
+      .finally(() => { if (!cancelled) setInsightLoading(false); });
+    return () => { cancelled = true; };
+  }, [repos, aiConfig]);
 
   // バックグラウンド AI 更新イベント
   useEffect(() => {
@@ -167,8 +186,20 @@ export default function AiAssistant() {
             aiFailed={aiFailed}
             ollamaOffline={ollamaOffline}
           />
+          {/* 同名 repo 区別のため path を補助表示（根本対応は別 Issue） */}
+          {selectedRepo && (
+            <div style={{
+              fontSize: 10, color: 'var(--text3)',
+              fontFamily: 'var(--font-mono)', marginBottom: 8,
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>
+              {selectedRepo.path}
+            </div>
+          )}
           {!selectedRepo ? (
             <EmptyState message="リポジトリを選択してください" />
+          ) : !aiEnabled ? (
+            <EmptyState message="AI Insight が無効化されています。Settings で有効化してください" tone="amber" />
           ) : insightLoading ? (
             <EmptyState message="分析中…" />
           ) : selectedInsights.length > 0 ? (
@@ -190,11 +221,14 @@ export default function AiAssistant() {
           <SectionHeader title="ALL REPOSITORIES" />
           {repos.length === 0 ? (
             <EmptyState message="リポジトリが登録されていません" />
+          ) : !aiEnabled ? (
+            <EmptyState message="AI Insight が無効化されています。Settings で有効化してください" tone="amber" />
           ) : (
             repos.map((r) => (
               <RepoInsightGroup
                 key={r.path}
                 repoName={r.name}
+                repoPath={r.path}
                 insights={insightsByRepo[r.name] ?? []}
               />
             ))
@@ -380,7 +414,11 @@ function InsightDetailCard({ insight }: { insight: Insight }) {
   );
 }
 
-function RepoInsightGroup({ repoName, insights }: { repoName: string; insights: Insight[] }) {
+function RepoInsightGroup({ repoName, repoPath, insights }: {
+  repoName: string;
+  repoPath: string;
+  insights: Insight[];
+}) {
   return (
     <div style={{
       padding: '10px 14px',
@@ -389,14 +427,22 @@ function RepoInsightGroup({ repoName, insights }: { repoName: string; insights: 
       borderRadius: 'var(--r)',
       marginBottom: 6,
     }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: insights.length > 0 ? 8 : 0 }}>
-        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--indigo-l)', flex: 1 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 2 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--indigo-l)' }}>
           {repoName}
         </span>
-        <span style={{ fontSize: 10, color: 'var(--text3)' }}>
+        <span style={{
+          flex: 1, fontSize: 10, color: 'var(--text3)',
+          fontFamily: 'var(--font-mono)',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
+        }}>
+          {repoPath}
+        </span>
+        <span style={{ fontSize: 10, color: 'var(--text3)', flexShrink: 0 }}>
           {insights.length === 0 ? '— no insights' : `${insights.length} insight${insights.length === 1 ? '' : 's'}`}
         </span>
       </div>
+      <div style={{ height: insights.length > 0 ? 6 : 0 }} />
       {insights.map((ins, i) => {
         const s = INSIGHT_STYLE[ins.type];
         return (

--- a/src/views/AiAssistant.tsx
+++ b/src/views/AiAssistant.tsx
@@ -1,0 +1,438 @@
+import { useEffect, useState } from 'react';
+import { listen } from '@tauri-apps/api/event';
+import { useRepoStore } from '../stores/repoStore';
+import { useUiStore } from '../stores/uiStore';
+import AppBar, { AppBtn } from '../components/AppBar';
+import { getAiInsights, getConfig, ollamaAvailable } from '../lib/invoke';
+import { convertAiInsights, fetchInsights, type InsightSource } from '../lib/aiService';
+import type { AiConfig, AiInsight, Insight } from '../types';
+
+type ConnectionState = 'unknown' | 'checking' | 'connected' | 'disconnected';
+
+const INSIGHT_STYLE: Record<Insight['type'], { bg: string; border: string; icon: string; color: string; label: string }> = {
+  risk:       { bg: 'var(--red-bg)',    border: '#f8717128', icon: '⚠', color: 'var(--red)',     label: 'Risk' },
+  prioritize: { bg: 'var(--amber-bg)',  border: '#fbbf2428', icon: '↑', color: 'var(--amber)',   label: 'Prioritize' },
+  explain:    { bg: 'var(--indigo-bg)', border: '#818cf828', icon: '●', color: 'var(--indigo-l)', label: 'Explain' },
+};
+
+const PRIORITY_COLOR: Record<Insight['priority'], string> = {
+  high:   'var(--red)',
+  medium: 'var(--amber)',
+  low:    'var(--text3)',
+};
+
+export default function AiAssistant() {
+  const { repos, selectedRepo } = useRepoStore();
+  const { addToast, navigate } = useUiStore();
+
+  const [aiConfig, setAiConfig] = useState<AiConfig | null>(null);
+  const [connection, setConnection] = useState<ConnectionState>('unknown');
+
+  const [insights, setInsights]         = useState<Insight[]>([]);
+  const [source, setSource]             = useState<InsightSource>('rule');
+  const [insightLoading, setInsightLoading] = useState(false);
+  const [aiBgRunning, setAiBgRunning]   = useState(false);
+  const [aiFailed, setAiFailed]         = useState(false);
+  const [ollamaOffline, setOllamaOffline] = useState(false);
+  const [reanalyzing, setReanalyzing]   = useState(false);
+
+  // 接続テスト：Settings の testAiConnection はフォーム入力中の URL を検証するためのもの。
+  // ここでは保存済み config を使って稼働確認したいので ollamaAvailable を使う。
+  const checkConnection = () => {
+    setConnection('checking');
+    ollamaAvailable()
+      .then((ok) => setConnection(ok ? 'connected' : 'disconnected'))
+      .catch(() => setConnection('disconnected'));
+  };
+
+  // 初回ロード：AI config と接続状態を取得
+  useEffect(() => {
+    let cancelled = false;
+    getConfig()
+      .then((cfg) => { if (!cancelled) setAiConfig(cfg.ai); })
+      .catch(() => {});
+    checkConnection();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Insight 取得（repos 変更時に再実行）
+  useEffect(() => {
+    if (repos.length === 0) {
+      setInsights([]);
+      setOllamaOffline(false);
+      setAiBgRunning(false);
+      setAiFailed(false);
+      return;
+    }
+    setInsightLoading(true);
+    setAiFailed(false);
+    fetchInsights(repos, {}, 14)
+      .then(({ insights: ins, source: s, ollamaOffline: offline }) => {
+        setInsights(ins);
+        setSource(s);
+        setOllamaOffline(offline);
+      })
+      .finally(() => setInsightLoading(false));
+  }, [repos]);
+
+  // バックグラウンド AI 更新イベント
+  useEffect(() => {
+    const unUpdated = listen<AiInsight[]>('ai_insights_updated', (ev) => {
+      setInsights(convertAiInsights(ev.payload));
+      setSource('ai');
+      setAiBgRunning(false);
+      setAiFailed(false);
+    });
+    const unLoading = listen<void>('ai_insights_loading', () => {
+      setAiBgRunning(true);
+      setAiFailed(false);
+    });
+    const unFailed = listen<void>('ai_insights_failed', () => {
+      setAiBgRunning(false);
+      setAiFailed(true);
+    });
+    return () => {
+      unUpdated.then((f) => f());
+      unLoading.then((f) => f());
+      unFailed.then((f) => f());
+    };
+  }, []);
+
+  // 再分析：キャッシュをバイパスして強制再生成（getAiInsightsCached ではなく getAiInsights を直接呼ぶ）
+  const handleReanalyze = async () => {
+    if (repos.length === 0) return;
+    setReanalyzing(true);
+    setAiFailed(false);
+    try {
+      const raw = await getAiInsights(repos);
+      setInsights(convertAiInsights(raw));
+      setSource('ai');
+      setOllamaOffline(false);
+      addToast('AI 再分析が完了しました', 'success');
+    } catch (e) {
+      setAiFailed(true);
+      addToast(`AI 分析に失敗しました: ${String(e)}`, 'error');
+    } finally {
+      setReanalyzing(false);
+    }
+  };
+
+  // リポジトリ別に Insight をグルーピング（target == repo.name）
+  const insightsByRepo = repos.reduce<Record<string, Insight[]>>((acc, r) => {
+    acc[r.name] = insights.filter((i) => i.target === r.name);
+    return acc;
+  }, {});
+  const selectedInsights = selectedRepo ? insightsByRepo[selectedRepo.name] ?? [] : [];
+
+  const aiEnabled = aiConfig?.enabled ?? false;
+  const reanalyzeDisabled =
+    reanalyzing || repos.length === 0 || connection !== 'connected' || !aiEnabled;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <AppBar
+        path={<span style={{ color: 'var(--text2)' }}>AI Assistant</span>}
+        actions={
+          <>
+            <AppBtn onClick={checkConnection} disabled={connection === 'checking'}>
+              {connection === 'checking' ? 'Testing…' : '接続テスト'}
+            </AppBtn>
+            <AppBtn
+              variant="primary"
+              onClick={handleReanalyze}
+              disabled={reanalyzeDisabled}
+              title={!aiEnabled ? 'AI Insight が無効です（Settings で有効化）' : undefined}
+            >
+              {reanalyzing ? '分析中…' : '⟳ 再分析'}
+            </AppBtn>
+          </>
+        }
+      />
+
+      <div style={{ flex: 1, padding: 16, overflowY: 'auto' }}>
+        {/* 接続ステータス */}
+        <ConnectionCard
+          connection={connection}
+          aiConfig={aiConfig}
+          onOpenSettings={() => navigate('settings')}
+        />
+
+        {/* 選択中リポジトリ */}
+        <section style={{ marginTop: 20 }}>
+          <SectionHeader
+            title={selectedRepo ? `AI INSIGHTS — ${selectedRepo.name}` : 'AI INSIGHTS'}
+            source={source}
+            loading={insightLoading}
+            aiBgRunning={aiBgRunning}
+            aiFailed={aiFailed}
+            ollamaOffline={ollamaOffline}
+          />
+          {!selectedRepo ? (
+            <EmptyState message="リポジトリを選択してください" />
+          ) : insightLoading ? (
+            <EmptyState message="分析中…" />
+          ) : selectedInsights.length > 0 ? (
+            selectedInsights.map((ins, i) => <InsightDetailCard key={i} insight={ins} />)
+          ) : aiBgRunning ? (
+            <EmptyState message="AI が分析中です…" />
+          ) : (
+            <EmptyState
+              message={ollamaOffline
+                ? 'Ollama が未起動のため AI 分析を実行できません'
+                : '✓ このリポジトリに特筆すべき項目はありません'}
+              tone={ollamaOffline ? 'amber' : 'green'}
+            />
+          )}
+        </section>
+
+        {/* 全リポジトリ */}
+        <section style={{ marginTop: 24 }}>
+          <SectionHeader title="ALL REPOSITORIES" />
+          {repos.length === 0 ? (
+            <EmptyState message="リポジトリが登録されていません" />
+          ) : (
+            repos.map((r) => (
+              <RepoInsightGroup
+                key={r.path}
+                repoName={r.name}
+                insights={insightsByRepo[r.name] ?? []}
+              />
+            ))
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionCard({
+  connection,
+  aiConfig,
+  onOpenSettings,
+}: {
+  connection: ConnectionState;
+  aiConfig: AiConfig | null;
+  onOpenSettings: () => void;
+}) {
+  const provider = aiConfig?.provider ?? '—';
+  const model    = aiConfig?.model ?? '—';
+  const enabled  = aiConfig?.enabled ?? false;
+
+  const statusInfo = (() => {
+    if (!enabled) return { icon: '○', color: 'var(--text3)', text: 'AI Insight は無効化されています' };
+    switch (connection) {
+      case 'checking':     return { icon: '⟳', color: 'var(--text3)', text: '接続確認中…' };
+      case 'connected':    return { icon: '✓', color: 'var(--green)', text: 'Ollama に接続済み' };
+      case 'disconnected': return { icon: '✗', color: 'var(--red)',   text: 'Ollama に接続できません' };
+      default:             return { icon: '·', color: 'var(--text3)', text: '未確認' };
+    }
+  })();
+
+  return (
+    <div style={{
+      background: 'var(--bg3)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--r2)',
+      padding: '14px 16px',
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10 }}>
+        <span style={{ fontSize: 14, color: statusInfo.color, width: 16, textAlign: 'center' }}>
+          {statusInfo.icon}
+        </span>
+        <span style={{ fontSize: 12, color: statusInfo.color, fontWeight: 600, flex: 1 }}>
+          {statusInfo.text}
+        </span>
+        <AppBtn onClick={onOpenSettings}>Settings</AppBtn>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginLeft: 26 }}>
+        <KeyValue label="PROVIDER" value={provider} />
+        <KeyValue label="MODEL"    value={model} mono />
+      </div>
+    </div>
+  );
+}
+
+function KeyValue({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div style={{ fontSize: 9, color: 'var(--text3)', fontWeight: 600, letterSpacing: '.12em', marginBottom: 2 }}>
+        {label}
+      </div>
+      <div style={{
+        fontSize: 11,
+        color: 'var(--text1)',
+        fontFamily: mono ? 'var(--font-mono)' : undefined,
+      }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({
+  title,
+  source,
+  loading,
+  aiBgRunning,
+  aiFailed,
+  ollamaOffline,
+}: {
+  title: string;
+  source?: InsightSource;
+  loading?: boolean;
+  aiBgRunning?: boolean;
+  aiFailed?: boolean;
+  ollamaOffline?: boolean;
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+      <span style={{
+        fontSize: 10, fontWeight: 600, color: 'var(--text3)',
+        letterSpacing: '.1em', flex: 1,
+      }}>
+        {title}
+      </span>
+      {loading && (
+        <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 9, color: 'var(--text3)', fontWeight: 600 }}>
+          <span className="arbor-spin">⟳</span> Rules…
+        </span>
+      )}
+      {!loading && aiBgRunning && (
+        <span style={{
+          display: 'flex', alignItems: 'center', gap: 4,
+          fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+          background: 'var(--indigo-bg2)', color: 'var(--indigo-l)',
+        }}>
+          <span className="arbor-pulse">✦</span> AI 分析中…
+        </span>
+      )}
+      {!loading && !aiBgRunning && aiFailed && (
+        <span style={{
+          fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+          background: 'var(--amber-bg)', color: 'var(--amber)',
+        }}>
+          ✗ AI 失敗
+        </span>
+      )}
+      {!loading && !aiBgRunning && !aiFailed && ollamaOffline && (
+        <span style={{
+          fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+          background: 'var(--amber-bg)', color: 'var(--amber)',
+        }}>
+          ⚠ Offline
+        </span>
+      )}
+      {!loading && !aiBgRunning && !aiFailed && !ollamaOffline && source && (
+        <span style={{
+          fontSize: 9, padding: '2px 6px', borderRadius: 4, fontWeight: 600,
+          background: source === 'ai' ? 'var(--indigo-bg2)' : 'var(--bg3)',
+          color:      source === 'ai' ? 'var(--indigo-l)'   : 'var(--text3)',
+        }}>
+          {source === 'ai' ? '✦ AI' : 'Rules'}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function InsightDetailCard({ insight }: { insight: Insight }) {
+  const s = INSIGHT_STYLE[insight.type];
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'flex-start', gap: 12,
+      padding: '12px 14px', background: s.bg,
+      border: `1px solid ${s.border}`, borderRadius: 'var(--r2)',
+      marginBottom: 6,
+    }}>
+      <span style={{ color: s.color, fontSize: 16, lineHeight: 1.2, flexShrink: 0 }}>{s.icon}</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <span style={{ fontSize: 11, fontWeight: 600, color: s.color, letterSpacing: '.06em' }}>
+            {s.label}
+          </span>
+          <span style={{ fontSize: 10, color: 'var(--text3)' }}>·</span>
+          <span style={{ fontSize: 11, color: 'var(--text1)', fontWeight: 600 }}>
+            {insight.target}
+          </span>
+          <span style={{ flex: 1 }} />
+          <span style={{
+            fontSize: 9, padding: '2px 6px', borderRadius: 4,
+            background: `${PRIORITY_COLOR[insight.priority]}18`,
+            color: PRIORITY_COLOR[insight.priority],
+            fontWeight: 600,
+          }}>
+            {insight.priority}
+          </span>
+          <span style={{
+            fontSize: 9, padding: '2px 6px', borderRadius: 4,
+            background: insight.source === 'ai' ? 'var(--indigo-bg2)' : 'var(--bg3)',
+            color:      insight.source === 'ai' ? 'var(--indigo-l)'   : 'var(--text3)',
+            fontWeight: 600,
+          }}>
+            {insight.source === 'ai' ? '✦ AI' : 'Rules'}
+          </span>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--text2)', lineHeight: 1.6 }}>
+          {insight.reason}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RepoInsightGroup({ repoName, insights }: { repoName: string; insights: Insight[] }) {
+  return (
+    <div style={{
+      padding: '10px 14px',
+      background: 'var(--bg3)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--r)',
+      marginBottom: 6,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: insights.length > 0 ? 8 : 0 }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--indigo-l)', flex: 1 }}>
+          {repoName}
+        </span>
+        <span style={{ fontSize: 10, color: 'var(--text3)' }}>
+          {insights.length === 0 ? '— no insights' : `${insights.length} insight${insights.length === 1 ? '' : 's'}`}
+        </span>
+      </div>
+      {insights.map((ins, i) => {
+        const s = INSIGHT_STYLE[ins.type];
+        return (
+          <div key={i} style={{
+            display: 'flex', alignItems: 'flex-start', gap: 8,
+            padding: '6px 0', borderTop: i > 0 ? '1px solid var(--border)' : undefined,
+          }}>
+            <span style={{ color: s.color, fontSize: 11, flexShrink: 0, width: 14, textAlign: 'center' }}>
+              {s.icon}
+            </span>
+            <span style={{ fontSize: 10, color: 'var(--text2)', lineHeight: 1.5, flex: 1 }}>
+              {ins.reason}
+            </span>
+            <span style={{
+              fontSize: 9, padding: '1px 5px', borderRadius: 3, flexShrink: 0,
+              background: `${PRIORITY_COLOR[ins.priority]}18`,
+              color: PRIORITY_COLOR[ins.priority],
+              fontWeight: 600,
+            }}>
+              {ins.priority}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EmptyState({ message, tone }: { message: string; tone?: 'green' | 'amber' }) {
+  const color =
+    tone === 'green' ? 'var(--green)' :
+    tone === 'amber' ? 'var(--amber)' :
+    'var(--text3)';
+  return (
+    <div style={{ fontSize: 11, color, padding: '8px 2px' }}>
+      {message}
+    </div>
+  );
+}

--- a/src/views/Overview.tsx
+++ b/src/views/Overview.tsx
@@ -25,7 +25,7 @@ function statusBadge(repo: RepoInfo) {
 
 export default function Overview() {
   const { repos, selectedRepo, selectRepo, refreshRepo } = useRepoStore();
-  const { addToast, setDsxRunning, dsxProgress, dsxRunning, clearDsxProgress } = useUiStore();
+  const { addToast, setDsxRunning, dsxProgress, dsxRunning, clearDsxProgress, navigate } = useUiStore();
 
   const [insights, setInsights]           = useState<Insight[]>([]);
   const [insightSource, setInsightSource] = useState<InsightSource>('rule');
@@ -206,6 +206,17 @@ export default function Overview() {
               <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--text3)', letterSpacing: '.1em', flex: 1 }}>
                 RECOMMENDED ACTIONS
               </span>
+              <button
+                onClick={() => navigate('ai')}
+                style={{
+                  fontSize: 10, color: 'var(--indigo-l)',
+                  background: 'none', border: 'none', cursor: 'pointer',
+                  padding: 0, marginRight: 8,
+                }}
+                title="AI Assistant タブで詳細を表示"
+              >
+                詳細 →
+              </button>
               {/* フェーズバッジ — 状態の優先順位: loading > aiBg > failed > offline > done */}
               {insightLoading && (
                 <span style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 9, color: 'var(--text3)', fontWeight: 600 }}>


### PR DESCRIPTION
Phase 3 で実装した AI Insight Engine の表示を専用タブに集約し、Settings は
設定編集、AI Assistant は分析結果ビューとして役割を分離する。

- ViewId に 'ai' を追加し Sidebar / CommandPalette / App.tsx にナビ登録
- src/views/AiAssistant.tsx 新規:
  - 接続ステータスカード（Ollama 接続状態 + provider/model 表示）
  - 接続テストボタン（保存済み config を使う ollamaAvailable 経由）
  - 選択リポジトリ用の Insight 詳細カード（Risk/Prioritize/Explain）
  - 全リポジトリ別 Insight グループ
  - 再分析ボタン（getAiInsights を直接呼んでキャッシュをバイパス）
  - 'ai_insights_updated/loading/failed' イベントの購読
- Overview の RECOMMENDED ACTIONS ヘッダに AI Assistant への "詳細 →" リンク
- AiAssistant.test.tsx: 接続ステータス・再分析ボタン状態・Insight 表示