### PR TITLE
refactor(ai): Insight を repo_path で識別して同名 repo の混在を防ぐ (#135)

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -69,6 +69,9 @@ fn build_state_summary(repos: &[RepoInfo]) -> String {
     #[derive(Serialize)]
     struct RepoSummary<'a> {
         name: &'a str,
+        /// Canonical identifier — AI must echo this back as `repo_path` so the
+        /// frontend can disambiguate same-name repos under different roots.
+        path: &'a str,
         branch: &'a str,
         ahead: u32,
         behind: u32,
@@ -81,6 +84,7 @@ fn build_state_summary(repos: &[RepoInfo]) -> String {
         .iter()
         .map(|r| RepoSummary {
             name: &r.name,
+            path: &r.path,
             branch: &r.current_branch,
             ahead: r.ahead,
             behind: r.behind,
@@ -102,8 +106,10 @@ fn build_prompt(state_json: &str) -> String {
          Analyze the following repository states and return ONLY a JSON array — \
          no explanation, no markdown, no code fences. \
          Each element must have exactly these fields: \
-         {{\"repo_name\": string, \"kind\": \"explain\"|\"prioritize\"|\"risk\", \
+         {{\"repo_name\": string, \"repo_path\": string, \
+         \"kind\": \"explain\"|\"prioritize\"|\"risk\", \
          \"message\": string, \"priority\": 0-3}}. \
+         Copy `repo_name` and `repo_path` verbatim from the input — never invent or modify them. \
          Repository states:\n{state_json}"
     )
 }
@@ -133,6 +139,22 @@ fn parse_insights(raw: &str) -> Result<Vec<AiInsight>, String> {
         }
     }
     Ok(insights)
+}
+
+/// AI が返した insight のうち、入力 repo リストに存在する `repo_path` を持つものだけ残す。
+///
+/// AI は `repo_path` を入力からそのまま echo back するよう指示しているが、ハルシネーションで
+/// path を改変したり、欠落させたりするケースがある。誤帰属（別 repo の insight が表示される）
+/// よりは insight が消える方が害が少ないため、不一致は黙ってドロップする。
+/// 同名 repo の path 取り違えを救済するために name 一致での再マッピングは敢えて行わない
+/// （同名重複時に AI が混乱しても誤帰属を作らないため）。
+fn filter_valid_repo_path(insights: Vec<AiInsight>, repos: &[RepoInfo]) -> Vec<AiInsight> {
+    use std::collections::HashSet;
+    let valid_paths: HashSet<&str> = repos.iter().map(|r| r.path.as_str()).collect();
+    insights
+        .into_iter()
+        .filter(|i| valid_paths.contains(i.repo_path.as_str()))
+        .collect()
 }
 
 fn ollama_url(base: &str, path: &str) -> String {
@@ -196,7 +218,8 @@ async fn fetch_from_ollama(repos: &[RepoInfo]) -> Result<Vec<AiInsight>, String>
         .await
         .map_err(|e| format!("Ollama レスポンスのパースに失敗しました: {e}"))?;
 
-    parse_insights(&gen.response)
+    let insights = parse_insights(&gen.response)?;
+    Ok(filter_valid_repo_path(insights, &interesting_owned))
 }
 
 // ─── Tauri commands ───────────────────────────────────────────────────────────
@@ -396,19 +419,21 @@ mod tests {
     }
 
     #[test]
-    fn build_state_summary_includes_repo_name() {
+    fn build_state_summary_includes_repo_name_and_path() {
         let repos = vec![make_repo("myrepo", 2, 5, 3)];
         let s = build_state_summary(&repos);
         assert!(s.contains("myrepo"), "state summary should contain repo name: {s}");
+        assert!(s.contains("/repos/myrepo"), "state summary should contain repo path: {s}");
         assert!(s.contains("\"ahead\":2"), "{s}");
         assert!(s.contains("\"behind\":5"), "{s}");
     }
 
     #[test]
     fn build_prompt_contains_no_think_prefix() {
-        let prompt = build_prompt(r#"[{"name":"x"}]"#);
+        let prompt = build_prompt(r#"[{"name":"x","path":"/p"}]"#);
         assert!(prompt.starts_with("/no_think"), "prompt must start with /no_think");
         assert!(prompt.contains("JSON array"), "{prompt}");
+        assert!(prompt.contains("repo_path"), "prompt must instruct AI to return repo_path");
     }
 
     #[test]
@@ -431,20 +456,22 @@ mod tests {
 
     #[test]
     fn parse_insights_valid_json() {
-        let raw = r#"[{"repo_name":"repo1","kind":"risk","message":"diverged","priority":3}]"#;
+        let raw = r#"[{"repo_name":"repo1","repo_path":"/repos/repo1","kind":"risk","message":"diverged","priority":3}]"#;
         let insights = parse_insights(raw).unwrap();
         assert_eq!(insights.len(), 1);
         assert_eq!(insights[0].repo_name, "repo1");
+        assert_eq!(insights[0].repo_path, "/repos/repo1");
         assert_eq!(insights[0].kind, InsightKind::Risk);
         assert_eq!(insights[0].priority, 3);
     }
 
     #[test]
     fn parse_insights_with_fence() {
-        let raw = "```json\n[{\"repo_name\":\"r\",\"kind\":\"explain\",\"message\":\"ok\",\"priority\":0}]\n```";
+        let raw = "```json\n[{\"repo_name\":\"r\",\"repo_path\":\"/p/r\",\"kind\":\"explain\",\"message\":\"ok\",\"priority\":0}]\n```";
         let insights = parse_insights(raw).unwrap();
         assert_eq!(insights.len(), 1);
         assert_eq!(insights[0].repo_name, "r");
+        assert_eq!(insights[0].repo_path, "/p/r");
         assert_eq!(insights[0].kind, InsightKind::Explain);
     }
 
@@ -456,16 +483,110 @@ mod tests {
 
     #[test]
     fn parse_insights_invalid_kind_returns_err() {
-        let raw = r#"[{"repo_name":"r","kind":"warning","message":"x","priority":1}]"#;
+        let raw = r#"[{"repo_name":"r","repo_path":"/p","kind":"warning","message":"x","priority":1}]"#;
         let err = parse_insights(raw).unwrap_err();
         assert!(err.contains("JSON パース"), "{err}");
     }
 
     #[test]
     fn parse_insights_priority_out_of_range_returns_err() {
-        let raw = r#"[{"repo_name":"r","kind":"risk","message":"x","priority":99}]"#;
+        let raw = r#"[{"repo_name":"r","repo_path":"/p","kind":"risk","message":"x","priority":99}]"#;
         let err = parse_insights(raw).unwrap_err();
         assert!(err.contains("priority"), "{err}");
+    }
+
+    #[test]
+    fn parse_insights_missing_repo_path_returns_err() {
+        // serde は repo_path 必須 → 欠落するとデシリアライズで弾かれる
+        let raw = r#"[{"repo_name":"r","kind":"risk","message":"x","priority":1}]"#;
+        let err = parse_insights(raw).unwrap_err();
+        assert!(err.contains("JSON パース"), "{err}");
+    }
+
+    #[test]
+    fn filter_valid_repo_path_keeps_matching_paths() {
+        let repos = vec![make_repo("a", 0, 0, 0), make_repo("b", 0, 0, 0)];
+        let insights = vec![
+            AiInsight {
+                repo_name: "a".into(),
+                repo_path: "/repos/a".into(),
+                kind: InsightKind::Explain,
+                message: "ok".into(),
+                priority: 1,
+            },
+            AiInsight {
+                repo_name: "b".into(),
+                repo_path: "/repos/b".into(),
+                kind: InsightKind::Risk,
+                message: "ng".into(),
+                priority: 3,
+            },
+        ];
+        let filtered = filter_valid_repo_path(insights, &repos);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn filter_valid_repo_path_drops_hallucinated_paths() {
+        // AI が存在しない path を返した場合は誤帰属を作らないようドロップする
+        let repos = vec![make_repo("a", 0, 0, 0)];
+        let insights = vec![
+            AiInsight {
+                repo_name: "a".into(),
+                repo_path: "/repos/a".into(),
+                kind: InsightKind::Explain,
+                message: "real".into(),
+                priority: 1,
+            },
+            AiInsight {
+                repo_name: "ghost".into(),
+                repo_path: "/repos/ghost".into(),
+                kind: InsightKind::Risk,
+                message: "hallucinated".into(),
+                priority: 3,
+            },
+        ];
+        let filtered = filter_valid_repo_path(insights, &repos);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].repo_path, "/repos/a");
+    }
+
+    #[test]
+    fn filter_valid_repo_path_handles_same_name_different_paths() {
+        // 同名 repo がある場合、path が一致するものだけ残す（name lookup フォールバックなし）
+        let mut repo_a1 = make_repo("alpha", 0, 0, 0);
+        repo_a1.path = "/root1/alpha".into();
+        let mut repo_a2 = make_repo("alpha", 0, 0, 0);
+        repo_a2.path = "/root2/alpha".into();
+        let repos = vec![repo_a1, repo_a2];
+
+        let insights = vec![
+            AiInsight {
+                repo_name: "alpha".into(),
+                repo_path: "/root1/alpha".into(),
+                kind: InsightKind::Explain,
+                message: "root1".into(),
+                priority: 1,
+            },
+            AiInsight {
+                repo_name: "alpha".into(),
+                repo_path: "/root2/alpha".into(),
+                kind: InsightKind::Risk,
+                message: "root2".into(),
+                priority: 3,
+            },
+            AiInsight {
+                repo_name: "alpha".into(),
+                repo_path: "/nowhere/alpha".into(),
+                kind: InsightKind::Risk,
+                message: "lost".into(),
+                priority: 2,
+            },
+        ];
+        let filtered = filter_valid_repo_path(insights, &repos);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().any(|i| i.repo_path == "/root1/alpha"));
+        assert!(filtered.iter().any(|i| i.repo_path == "/root2/alpha"));
     }
 
     #[test]
@@ -509,6 +630,7 @@ mod tests {
         let cache = AiCacheState::default();
         let insight = AiInsight {
             repo_name: "r".to_string(),
+            repo_path: "/repos/r".to_string(),
             kind: InsightKind::Explain,
             message: "ok".to_string(),
             priority: 1,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -128,9 +128,14 @@ pub enum InsightKind {
 }
 
 /// A single AI-generated insight for a repository.
+///
+/// `repo_path` is the canonical identifier (Arbor allows same-name repos under
+/// different root directories, so name alone is ambiguous). `repo_name` is
+/// kept as a display label.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiInsight {
     pub repo_name: String,
+    pub repo_path: String,
     pub kind: InsightKind,
     pub message: String,
     /// Priority level: 0 = lowest, 3 = highest urgency.

--- a/src/lib/aiService.test.ts
+++ b/src/lib/aiService.test.ts
@@ -26,13 +26,13 @@ const REPOS: RepoInfo[] = [
 const BRANCHES: Record<string, BranchInfo[]> = {};
 
 const RULE_INSIGHTS: Insight[] = [
-  { type: 'explain', target: 'alpha', priority: 'low', reason: 'rule', source: 'rule' },
+  { type: 'explain', target: 'alpha', repo_path: '/repos/alpha', priority: 'low', reason: 'rule', source: 'rule' },
 ];
 
 const AI_RAW: AiInsight[] = [
-  { repo_name: 'alpha', kind: 'risk', message: 'diverged', priority: 3 },
-  { repo_name: 'alpha', kind: 'prioritize', message: 'pull needed', priority: 2 },
-  { repo_name: 'alpha', kind: 'explain', message: 'stale branch', priority: 0 },
+  { repo_name: 'alpha', repo_path: '/repos/alpha', kind: 'risk', message: 'diverged', priority: 3 },
+  { repo_name: 'alpha', repo_path: '/repos/alpha', kind: 'prioritize', message: 'pull needed', priority: 2 },
+  { repo_name: 'alpha', repo_path: '/repos/alpha', kind: 'explain', message: 'stale branch', priority: 0 },
 ];
 
 beforeEach(() => {
@@ -44,24 +44,29 @@ beforeEach(() => {
 
 describe('convertAiInsights', () => {
   it('priority 3 → high', () => {
-    const insights = convertAiInsights([{ repo_name: 'r', kind: 'risk', message: 'x', priority: 3 }]);
+    const insights = convertAiInsights([{ repo_name: 'r', repo_path: '/p/r', kind: 'risk', message: 'x', priority: 3 }]);
     expect(insights[0].priority).toBe('high');
     expect(insights[0].source).toBe('ai');
   });
 
   it('priority 2 → high', () => {
-    const insights = convertAiInsights([{ repo_name: 'r', kind: 'prioritize', message: 'x', priority: 2 }]);
+    const insights = convertAiInsights([{ repo_name: 'r', repo_path: '/p/r', kind: 'prioritize', message: 'x', priority: 2 }]);
     expect(insights[0].priority).toBe('high');
   });
 
   it('priority 1 → medium', () => {
-    const insights = convertAiInsights([{ repo_name: 'r', kind: 'explain', message: 'x', priority: 1 }]);
+    const insights = convertAiInsights([{ repo_name: 'r', repo_path: '/p/r', kind: 'explain', message: 'x', priority: 1 }]);
     expect(insights[0].priority).toBe('medium');
   });
 
   it('priority 0 → low', () => {
-    const insights = convertAiInsights([{ repo_name: 'r', kind: 'explain', message: 'x', priority: 0 }]);
+    const insights = convertAiInsights([{ repo_name: 'r', repo_path: '/p/r', kind: 'explain', message: 'x', priority: 0 }]);
     expect(insights[0].priority).toBe('low');
+  });
+
+  it('copies repo_path through to Insight', () => {
+    const insights = convertAiInsights([{ repo_name: 'r', repo_path: '/root/dup/r', kind: 'risk', message: 'x', priority: 1 }]);
+    expect(insights[0].repo_path).toBe('/root/dup/r');
   });
 
   it('maps kind and message correctly', () => {

--- a/src/lib/aiService.ts
+++ b/src/lib/aiService.ts
@@ -29,6 +29,7 @@ export function convertAiInsights(raw: AiInsight[]): Insight[] {
   return raw.map((r) => ({
     type: r.kind,
     target: r.repo_name,
+    repo_path: r.repo_path,
     priority: PRIORITY_MAP[r.priority] ?? 'low',
     reason: r.message,
     source: 'ai' as const,

--- a/src/lib/ruleEngine.test.ts
+++ b/src/lib/ruleEngine.test.ts
@@ -151,4 +151,28 @@ describe('generateInsights', () => {
   it('empty repos list → empty insights', () => {
     expect(generateInsights([], {}, 14)).toHaveLength(0);
   });
+
+  it('全 insight に repo_path がセットされる（同名 repo 区別の前提）', () => {
+    const repoA = makeRepo({ path: '/root1/alpha', name: 'alpha', ahead: 1, behind: 1 });
+    const repoB = makeRepo({ path: '/root2/alpha', name: 'alpha', behind: 8 });
+    const staleBranch = makeBranch({
+      name: 'feature/old',
+      is_merged: false,
+      is_squash_merged: false,
+      last_commit_ts: Math.floor(Date.now() / 1000) - 30 * 86400,
+    });
+    const insights = generateInsights(
+      [repoA, repoB],
+      { [repoA.path]: [staleBranch], [repoB.path]: [] },
+      14,
+    );
+    // 全 insight に repo_path が入っている
+    for (const ins of insights) {
+      expect(ins.repo_path).toBeTruthy();
+      expect([repoA.path, repoB.path]).toContain(ins.repo_path);
+    }
+    // 同名 repo でも repo_path で区別できる
+    expect(insights.some((i) => i.repo_path === repoA.path)).toBe(true);
+    expect(insights.some((i) => i.repo_path === repoB.path)).toBe(true);
+  });
 });

--- a/src/lib/ruleEngine.ts
+++ b/src/lib/ruleEngine.ts
@@ -22,6 +22,7 @@ export function generateInsights(
       insights.push({
         type: 'risk',
         target: repo.name,
+        repo_path: repo.path,
         priority: 'high',
         reason: `${repo.ahead}コミット先行・${repo.behind}コミット遅延: diverged状態`,
         source: 'rule',
@@ -34,6 +35,7 @@ export function generateInsights(
       insights.push({
         type: 'prioritize',
         target: repo.name,
+        repo_path: repo.path,
         priority: 'high',
         reason: `リモートから${repo.behind}コミット遅れています`,
         source: 'rule',
@@ -50,13 +52,14 @@ export function generateInsights(
       insights.push({
         type: 'prioritize',
         target: repo.name,
+        repo_path: repo.path,
         priority: 'medium',
         reason: `${mergedCount}本のマージ済みブランチが残っています`,
         source: 'rule',
       });
     }
 
-    // Stale branches
+    // Stale branches — target は branch 名だが repo_path は親 repo を指す
     for (const branch of branches) {
       if (branch.is_current) continue;
       const ageSec = nowSec - branch.last_commit_ts;
@@ -65,6 +68,7 @@ export function generateInsights(
         insights.push({
           type: 'explain',
           target: branch.name,
+          repo_path: repo.path,
           priority: branch.behind >= 10 ? 'medium' : 'low',
           reason: `${ageDays}日間更新なし・mainから${branch.behind}コミット遅延`,
           source: 'rule',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,6 +138,11 @@ export interface CheckRun {
 /** Mirror of AiInsight in models.rs — raw response from get_ai_insights. */
 export interface AiInsight {
   repo_name: string;
+  /**
+   * Canonical repo identifier. Same-name repos under different roots are
+   * disambiguated by this field. Always matches a `RepoInfo.path`.
+   */
+  repo_path: string;
   /** "explain" | "prioritize" | "risk" */
   kind: InsightType;
   message: string;
@@ -160,7 +165,17 @@ export type InsightSource = 'rule' | 'ai';
 
 export interface Insight {
   type: InsightType;
+  /**
+   * Display label. For repo-level insights this is the repo name; for
+   * branch-level insights this is the branch name. Not unique — use
+   * `repo_path` for identification / grouping.
+   */
   target: string;
+  /**
+   * Canonical repo identifier (matches `RepoInfo.path`). Always set so
+   * insights can be grouped per-repo even when names collide.
+   */
+  repo_path: string;
   priority: 'low' | 'medium' | 'high';
   reason: string;
   source: InsightSource;

--- a/src/views/AiAssistant.test.tsx
+++ b/src/views/AiAssistant.test.tsx
@@ -155,7 +155,7 @@ describe('AiAssistant — 再分析ボタン', () => {
 
   it('正常時にクリックすると getAiInsights が呼ばれる', async () => {
     const mockInsights: AiInsight[] = [
-      { repo_name: 'alpha', kind: 'risk', message: '危険なブランチ', priority: 3 },
+      { repo_name: 'alpha', repo_path: '/repo/alpha', kind: 'risk', message: '危険なブランチ', priority: 3 },
     ];
     vi.mocked(invoke.getAiInsights).mockResolvedValue(mockInsights);
     act(() => {
@@ -184,8 +184,8 @@ describe('AiAssistant — Insight 表示', () => {
   it('選択リポジトリの insights だけがメインセクションに表示される', async () => {
     const repos = [makeRepo(), makeRepo({ path: '/repo/beta', name: 'beta' })];
     const insights: Insight[] = [
-      { type: 'risk',    target: 'alpha', priority: 'high',   reason: 'alpha-risk',    source: 'ai' },
-      { type: 'explain', target: 'beta',  priority: 'low',    reason: 'beta-explain',  source: 'ai' },
+      { type: 'risk',    target: 'alpha', repo_path: '/repo/alpha', priority: 'high',   reason: 'alpha-risk',    source: 'ai' },
+      { type: 'explain', target: 'beta',  repo_path: '/repo/beta',  priority: 'low',    reason: 'beta-explain',  source: 'ai' },
     ];
     vi.mocked(aiService.fetchInsights).mockResolvedValue({
       insights, source: 'ai', ollamaOffline: false,
@@ -241,6 +241,35 @@ describe('AiAssistant — Insight 表示', () => {
     await waitFor(() => {
       expect(screen.getAllByText('/work/clone-a/alpha').length).toBeGreaterThan(0);
       expect(screen.getAllByText('/work/clone-b/alpha').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('同名 repo の insight が path によって正しく分離される', async () => {
+    // 同名 repo を 2 つ用意し、それぞれに別の insight を割り当てる
+    const repoA = makeRepo({ path: '/work/clone-a/alpha', name: 'alpha' });
+    const repoB = makeRepo({ path: '/work/clone-b/alpha', name: 'alpha' });
+    const insights: Insight[] = [
+      // repo_path = clone-a を指す insight
+      { type: 'risk',    target: 'alpha', repo_path: '/work/clone-a/alpha',
+        priority: 'high', reason: 'clone-a-only-risk', source: 'ai' },
+      // repo_path = clone-b を指す insight
+      { type: 'explain', target: 'alpha', repo_path: '/work/clone-b/alpha',
+        priority: 'low',  reason: 'clone-b-only-explain', source: 'ai' },
+    ];
+    vi.mocked(aiService.fetchInsights).mockResolvedValue({
+      insights, source: 'ai', ollamaOffline: false,
+    });
+    act(() => {
+      useRepoStore.setState({ repos: [repoA, repoB], selectedRepo: repoA });
+    });
+    render(<AiAssistant />);
+    // selected = clone-a なので selected セクションに clone-a の reason のみが出る
+    // ALL REPOSITORIES グループは両方出るため、それぞれの reason が「丁度 1 回ずつ」現れる
+    await waitFor(() => {
+      // selected セクション + ALL REPOSITORIES の clone-a group の両方に表示 → 2 回
+      expect(screen.getAllByText('clone-a-only-risk').length).toBe(2);
+      // clone-b は selected ではないので ALL REPOSITORIES の clone-b group のみ → 1 回
+      expect(screen.getAllByText('clone-b-only-explain').length).toBe(1);
     });
   });
 });
@@ -313,7 +342,7 @@ describe('AiAssistant — イベント購読', () => {
       expect(eventHandlers.has('ai_insights_updated')).toBe(true);
     });
     const ai: AiInsight[] = [
-      { repo_name: 'alpha', kind: 'risk', message: 'event-pushed-risk', priority: 3 },
+      { repo_name: 'alpha', repo_path: '/repo/alpha', kind: 'risk', message: 'event-pushed-risk', priority: 3 },
     ];
     act(() => emitEvent('ai_insights_updated', ai));
     await waitFor(() => {

--- a/src/views/AiAssistant.tsx
+++ b/src/views/AiAssistant.tsx
@@ -141,12 +141,12 @@ export default function AiAssistant() {
     }
   };
 
-  // リポジトリ別に Insight をグルーピング（target == repo.name）
+  // リポジトリ別に Insight をグルーピング（path で識別 — 同名 repo を区別するため）
   const insightsByRepo = repos.reduce<Record<string, Insight[]>>((acc, r) => {
-    acc[r.name] = insights.filter((i) => i.target === r.name);
+    acc[r.path] = insights.filter((i) => i.repo_path === r.path);
     return acc;
   }, {});
-  const selectedInsights = selectedRepo ? insightsByRepo[selectedRepo.name] ?? [] : [];
+  const selectedInsights = selectedRepo ? insightsByRepo[selectedRepo.path] ?? [] : [];
 
   const aiEnabled = aiConfig?.enabled ?? false;
   const reanalyzeDisabled =
@@ -191,7 +191,7 @@ export default function AiAssistant() {
             aiFailed={aiFailed}
             ollamaOffline={ollamaOffline}
           />
-          {/* 同名 repo 区別のため path を補助表示（根本対応は別 Issue） */}
+          {/* path 補助表示: 同名 repo を視覚的に区別する（識別自体は repo_path で行う） */}
           {selectedRepo && (
             <div style={{
               fontSize: 10, color: 'var(--text3)',
@@ -234,7 +234,7 @@ export default function AiAssistant() {
                 key={r.path}
                 repoName={r.name}
                 repoPath={r.path}
-                insights={insightsByRepo[r.name] ?? []}
+                insights={insightsByRepo[r.path] ?? []}
               />
             ))
           )}

--- a/src/views/Cleanup.test.tsx
+++ b/src/views/Cleanup.test.tsx
@@ -5,6 +5,21 @@ import Cleanup from './Cleanup';
 import { useRepoStore } from '../stores/repoStore';
 import { useUiStore } from '../stores/uiStore';
 import * as invoke from '../lib/invoke';
+import * as aiService from '../lib/aiService';
+import type { Insight } from '../types';
+
+vi.mock('../lib/aiService', async () => {
+  const actual = await vi.importActual<typeof import('../lib/aiService')>('../lib/aiService');
+  return {
+    ...actual,
+    fetchInsights: vi.fn().mockResolvedValue({ insights: [], source: 'rule', ollamaOffline: false }),
+  };
+});
+
+// @tauri-apps/api/event の listen をスタブ化（jsdom では IPC 利用不可）
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
 
 const mockGetBranches = vi.spyOn(invoke, 'getBranches');
 
@@ -138,5 +153,96 @@ describe('Cleanup — ブランチ表示', () => {
     // タイトルは出るが main は表示されない
     await screen.findByText('MERGED BRANCHES');
     expect(screen.queryByText('main')).not.toBeInTheDocument();
+  });
+});
+
+describe('Cleanup — Insight 行コンテキストマッチング', () => {
+  const repo = makeRepo('/repo/a', 'repo-a');
+
+  it('branch-level insight は同じ repo の他ブランチ行に漏れない', async () => {
+    // 同じ repo に 2 つの stale branch、片方だけ branch-level insight を持つ
+    const insights: Insight[] = [
+      {
+        type: 'explain',
+        target: 'feature/old-a',           // 特定ブランチに紐づく
+        repo_path: '/repo/a',
+        priority: 'low',
+        reason: 'only-for-old-a',
+        source: 'rule',
+      },
+    ];
+    vi.mocked(aiService.fetchInsights).mockResolvedValue({
+      insights, source: 'rule', ollamaOffline: false,
+    });
+    mockGetBranches.mockResolvedValue([
+      makeBranch('feature/old-a'),
+      makeBranch('feature/old-b'),
+    ]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    await screen.findByText('feature/old-a');
+    await screen.findByText('feature/old-b');
+    // reason が出るのは feature/old-a 行のみで、feature/old-b 行には現れない
+    await waitFor(() => {
+      expect(screen.getAllByText(/only-for-old-a/).length).toBe(1);
+    });
+  });
+
+  it('branch-level insight が無い場合は repo-level insight にフォールバック', async () => {
+    const insights: Insight[] = [
+      {
+        type: 'risk',
+        target: 'repo-a',                  // repo-level (target == repo name)
+        repo_path: '/repo/a',
+        priority: 'high',
+        reason: 'repo-level-warning',
+        source: 'ai',
+      },
+    ];
+    vi.mocked(aiService.fetchInsights).mockResolvedValue({
+      insights, source: 'ai', ollamaOffline: false,
+    });
+    mockGetBranches.mockResolvedValue([
+      makeBranch('feature/x'),
+      makeBranch('feature/y'),
+    ]);
+    act(() => { useRepoStore.setState({ repos: [repo], selectedRepo: null }); });
+    renderCleanup();
+    await screen.findByText('feature/x');
+    await screen.findByText('feature/y');
+    // 両ブランチ行に repo-level reason が出る（行コンテキストでの fallback として妥当）
+    await waitFor(() => {
+      expect(screen.getAllByText(/repo-level-warning/).length).toBe(2);
+    });
+  });
+
+  it('別 path の同名 repo に insight が漏れない', async () => {
+    const repoA = makeRepo('/work/clone-a/alpha', 'alpha');
+    const repoB = makeRepo('/work/clone-b/alpha', 'alpha');
+    const insights: Insight[] = [
+      // clone-a のみに紐づく repo-level insight
+      {
+        type: 'risk',
+        target: 'alpha',
+        repo_path: '/work/clone-a/alpha',
+        priority: 'high',
+        reason: 'clone-a-warning',
+        source: 'ai',
+      },
+    ];
+    vi.mocked(aiService.fetchInsights).mockResolvedValue({
+      insights, source: 'ai', ollamaOffline: false,
+    });
+    mockGetBranches.mockImplementation((path: string) =>
+      Promise.resolve([makeBranch(path === '/work/clone-a/alpha' ? 'br-a' : 'br-b')]),
+    );
+    act(() => { useRepoStore.setState({ repos: [repoA, repoB], selectedRepo: null }); });
+    renderCleanup();
+    await screen.findByText('br-a');
+    await screen.findByText('br-b');
+    // clone-a の行にのみ reason が現れる、clone-b には現れない
+    await waitFor(() => {
+      expect(screen.getAllByText(/clone-a-warning/).length).toBe(1);
+    });
   });
 });

--- a/src/views/Cleanup.tsx
+++ b/src/views/Cleanup.tsx
@@ -32,7 +32,6 @@ export default function Cleanup() {
 
   // AI / ルールベース Insight を取得 (P3-08)
   // branchesByRepo を渡すことでルールエンジンのステールブランチ検出を有効化。
-  // AI Insight の target は repo_name なので repo 名で照合する。
   useEffect(() => {
     if (repos.length === 0) return;
     fetchInsights(repos, branchesByRepo, 14).then(({ insights: ins }) => setInsights(ins));
@@ -46,10 +45,9 @@ export default function Cleanup() {
     return () => { promise.then((f) => f()); };
   }, []);
 
-  // リポジトリ名で Insight を検索するヘルパー
-  // AI Insight / ルールベース repo-level Insight はいずれも target = repo_name。
-  const findInsightForRepo = (repoName: string): string | undefined =>
-    insights.find((ins) => ins.target === repoName)?.reason;
+  // リポジトリ path で Insight を検索するヘルパー（同名 repo の取り違えを防ぐため path 一致）
+  const findInsightForRepo = (repoPath: string): string | undefined =>
+    insights.find((ins) => ins.repo_path === repoPath)?.reason;
 
   // Load branches — scoped to selectedRepo if set, otherwise all repos.
   useEffect(() => {
@@ -223,7 +221,7 @@ export default function Cleanup() {
               checked={selected.has(makeKey(b._repoPath, b.name))}
               onToggle={() => toggleSelect(b._repoPath, b.name)}
               checkAccent="var(--red)"
-              aiReason={findInsightForRepo(b._repoName)}
+              aiReason={findInsightForRepo(b._repoPath)}
             />
           ))}
         </CleanupSection>
@@ -245,7 +243,7 @@ export default function Cleanup() {
                 checked={selected.has(makeKey(b._repoPath, b.name))}
                 onToggle={() => toggleSelect(b._repoPath, b.name)}
                 checkAccent="var(--indigo)"
-                aiReason={findInsightForRepo(b._repoName)}
+                aiReason={findInsightForRepo(b._repoPath)}
               />
             );
           })}

--- a/src/views/Cleanup.tsx
+++ b/src/views/Cleanup.tsx
@@ -45,9 +45,25 @@ export default function Cleanup() {
     return () => { promise.then((f) => f()); };
   }, []);
 
-  // リポジトリ path で Insight を検索するヘルパー（同名 repo の取り違えを防ぐため path 一致）
-  const findInsightForRepo = (repoPath: string): string | undefined =>
-    insights.find((ins) => ins.repo_path === repoPath)?.reason;
+  // Insight を行コンテキストで検索するヘルパー。
+  // - branch-level insight (ruleEngine の stale-branch) は target === branch 名
+  // - repo-level insight (AI / diverged 等) は target === repo 名
+  // 同じ repo に複数の branch-level insight がある場合に、各行で正しい reason が
+  // 出るよう、まず branch 名一致を試し、無ければ repo-level にフォールバックする。
+  const findInsightForRow = (
+    repoPath: string,
+    branchName: string,
+    repoName: string,
+  ): string | undefined => {
+    const branchHit = insights.find(
+      (ins) => ins.repo_path === repoPath && ins.target === branchName,
+    );
+    if (branchHit) return branchHit.reason;
+    const repoHit = insights.find(
+      (ins) => ins.repo_path === repoPath && ins.target === repoName,
+    );
+    return repoHit?.reason;
+  };
 
   // Load branches — scoped to selectedRepo if set, otherwise all repos.
   useEffect(() => {
@@ -221,7 +237,7 @@ export default function Cleanup() {
               checked={selected.has(makeKey(b._repoPath, b.name))}
               onToggle={() => toggleSelect(b._repoPath, b.name)}
               checkAccent="var(--red)"
-              aiReason={findInsightForRepo(b._repoPath)}
+              aiReason={findInsightForRow(b._repoPath, b.name, b._repoName)}
             />
           ))}
         </CleanupSection>
@@ -243,7 +259,7 @@ export default function Cleanup() {
                 checked={selected.has(makeKey(b._repoPath, b.name))}
                 onToggle={() => toggleSelect(b._repoPath, b.name)}
                 checkAccent="var(--indigo)"
-                aiReason={findInsightForRepo(b._repoPath)}
+                aiReason={findInsightForRow(b._repoPath, b.name, b._repoName)}
               />
             );
           })}


### PR DESCRIPTION
## Summary

PR #134 のレビュー指摘 (#1 / Codex P2) の根本対応。AI Insight をリポジトリ name ではなく **path で識別** することで、同名 repo を複数 root 配下に登録した際の insight 混在を防ぐ。

### Rust

- `AiInsight` に `repo_path: String` を追加（canonical identifier）
- `commands/ai.rs`:
  - state summary に `path` を含め、プロンプトで AI に `repo_path` を verbatim で返すよう指示
  - `filter_valid_repo_path` で入力 path に存在しない insight をドロップ
  - 同名 repo の取り違えを防ぐため、name 一致での fallback は敢えて行わない（誤帰属より insight 消失の方が害が少ない）

### Frontend

- `types/index.ts`: `AiInsight` / `Insight` に `repo_path` を必須フィールドとして追加
- `lib/ruleEngine.ts`: 全 insight (repo-level / branch-level) に `repo_path` をセット
- `lib/aiService.ts`: `convertAiInsights` で `repo_path` を伝搬
- `views/AiAssistant.tsx`: `insightsByRepo` を `r.path` keyed に変更、`selectedRepo.path` と `insight.repo_path` で照合
- `views/Cleanup.tsx`: `findInsightForRepo` の引数を `repoPath` に変更し `insight.repo_path` で照合
- `views/Overview.tsx`: 影響なし（`insight.target` を display label として表示するのみ）

### Tests

- 同名 repo を 2 つ登録したケースで insight が path で正しく分離されることを検証 (`AiAssistant.test.tsx`)
- ルールエンジンが全 insight に `repo_path` をセットすることを検証 (`ruleEngine.test.ts`)
- `filter_valid_repo_path` の動作（hallucination 除去 / 同名 path 区別）の Rust ユニットテストを追加 (`commands/ai.rs`)

## Test plan

- [x] `cargo check / clippy / test` (lefthook pre-push で実行済み)
- [x] `pnpm typecheck` (165 tests passed)
- [x] `pnpm test` 全件 green
- [ ] 手動確認: 同名 repo を 2 つ登録して AI Insight を取得 → selected セクションと ALL REPOSITORIES グループで混在しないこと

Closes #135
Related: PR #134, Issue #132

---
_Generated by [Claude Code](https://claude.ai/code/session_012v2pkXh6nWxCvoxSE2HSRB)_