### PR TITLE
chore(renovate): minimumReleaseAge を 3 days に設定して CI 落ちを防ぐ

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     "github>scottlz0310/renovate-config//presets/options/schedule",
     "github>scottlz0310/renovate-config//presets/options/security"
   ],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": ["cargo"],


### PR DESCRIPTION
## Summary

Renovate が新しすぎるパッケージで PR を作成すると、CI の `pnpm install` が supply-chain policy (`minimumReleaseAge` ≈ 24 時間) 違反で落ちる問題 (例: #133) への恒久対策。

Renovate 側に `minimumReleaseAge: "3 days"` を設定し、エイジング済みのバージョンでのみ PR を作るようにする。

## 設計

- pnpm 側のポリシーは 24 時間
- Renovate 側を **3 days** にして安全側マージンを確保（リリース直後のホットフィックス連発や CI 遅延でマージン切れを起こさないため）

これにより:
- CI 落ち → 手動 `minimumReleaseAgeExclude` 追加 → 再実行 のループが恒久的に消える
- `pnpm-workspace.yaml` の exclude リストにエントリが溜まり続けるのを防げる

## 影響範囲

- Renovate が新規 PR を出すまでに 3 日のラグが入る（セキュリティ重要度の高い更新は `presets/options/security` 側で個別に上書き可能）
- 既に作成済みの PR #133 はこの変更後も自動では再評価されない（PR を rebase / 再生成すれば反映される。または公開から 24h 経過後に自然と通る）

## Test plan

- [ ] Renovate がこの PR を merge した後の次の dependency 更新で、新しすぎるパッケージがスキップされていることを確認
- [ ] `pnpm-workspace.yaml` の `minimumReleaseAgeExclude` リストが増えなくなることを長期的に確認

Related: #133

---
_Generated by [Claude Code](https://claude.ai/code/session_012v2pkXh6nWxCvoxSE2HSRB)_