### PR TITLE
feat(updater): tauri.conf.json に minisign 公開鍵を登録 (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ### feat — Phase 4
 
+- **updater 公開鍵を tauri.conf.json に登録** (P4-05) (#139)
+  - `src-tauri/tauri.conf.json` の `plugins.updater.pubkey` に minisign 公開鍵を設定
+  - 対応する秘密鍵は GitHub Secrets (`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) に配置済み
+  - release workflow（#140）で `latest.json` 署名生成に使用予定
+
 - **コマンドパレット** (P4-01) (#102)
   - `Ctrl/Cmd+K` でパレットを開閉
   - ビュー遷移（7 件）・リポジトリ切替をインクリメンタル検索

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,7 @@
       "endpoints": [
         "https://github.com/scottlz0310/arbor/releases/latest/download/latest.json"
       ],
-      "pubkey": ""
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFENURBQThFRUNGQUE3QjMKUldTenAvcnNqcXBkSFdUMHloTlduR3dNdEkzYnloQVp6T3hnTE5Qb3ExdjUrMno2UlllWVZDeEYK"
     }
   }
 }

--- a/tasks.md
+++ b/tasks.md
@@ -164,17 +164,17 @@
 
 ## Phase 4 — UX 磨き + リリース (week 6)
 
-- [ ] P4-01: Cmd/Ctrl+K コマンドパレット
-- [ ] P4-02: `commands/repo.rs` — `list_stashes` / `apply_stash` / `drop_stash`
-- [ ] P4-03: `src/views/Stash.tsx` — Stash Manager UI (一覧 / apply / drop)
-- [ ] P4-04: dsx バージョン表示 + アップデート確認 UI (Settings 画面)
+- [x] P4-01: Cmd/Ctrl+K コマンドパレット
+- [x] P4-02: `commands/repo.rs` — `list_stashes` / `apply_stash` / `drop_stash`
+- [x] P4-03: `src/views/Stash.tsx` — Stash Manager UI (一覧 / apply / drop)
+- [x] P4-04: dsx バージョン表示 + アップデート確認 UI (Settings 画面)
 - [ ] P4-05: Tauri updater + GitHub Releases 自動更新フロー設定
 - [ ] P4-06: Windows (.msi) インストーラービルド (`tauri build`)
 - [ ] P4-07: macOS (.dmg) インストーラービルド
-- [ ] P4-08: README / CHANGELOG 整備
+- [x] P4-08: README / CHANGELOG 整備
 - [ ] P4-09: GitHub public release 公開 (v0.1.0)
-- [ ] P4-10: アクセシビリティ確認 (キーボードナビゲーション / フォーカス管理)
-- [ ] P4-11: `PullRequest` モデルに `head_sha` を追加し、CI check-runs のキーと API ref を SHA ベースに統一
+- [x] P4-10: アクセシビリティ確認 (キーボードナビゲーション / フォーカス管理)
+- [x] P4-11: `PullRequest` モデルに `head_sha` を追加し、CI check-runs のキーと API ref を SHA ベースに統一
        (現在は `pr.number` をキャッシュキーに使用。fork PR で同名ブランチが重複する場合の完全な解決策として Phase 4 で対応)
 - [x] P4-12: 削除済みリポジトリの一括登録解除 UI ([#117](https://github.com/scottlz0310/arbor/issues/117))
        - `scan_missing_repositories` コマンド追加（`Path::exists()` で存在チェック）


### PR DESCRIPTION
## Summary

- `src-tauri/tauri.conf.json` の `plugins.updater.pubkey` を空文字プレースホルダーから、ローカル生成済みの minisign 公開鍵に差し替え
- 対応する秘密鍵は GitHub Secrets (`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) に配置済み（手動オペレーション）
- release workflow (#140) で `latest.json` 署名生成に使用される

#138 / #143 で導入した updater プラグインの空文字 pubkey を実鍵で置き換える PR。Issue #139 のチェックリストのうち「公開鍵をアプリにコミット」に対応する。

## チェックリスト達成状況 (#139)

- [x] `~/.tauri/arbor.key` / `arbor.key.pub` 生成
- [x] `src-tauri/tauri.conf.json` の `pubkey` 更新（**本 PR**）
- [x] GitHub Secrets に `TAURI_SIGNING_PRIVATE_KEY` 登録
- [x] GitHub Secrets に `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` 登録
- [x] ローカル鍵 + パスワードのバックアップ

## Test plan

- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` が通る
- [ ] `pnpm tauri dev` で起動時に updater プラグインがエラーなく初期化される
- [ ] (#140 マージ後) release workflow が `latest.json` 署名生成に成功する

## 関連

- 親 Issue: #139 → #105
- 先行: #138 (PR #143 — プラグイン導入)
- 後続: #140 (release workflow が Secrets を利用)

## 補足

本 PR には別途、未 push だった main コミット `8c104a1`（tasks.md チェックマーク更新）も含まれます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)