### PR TITLE
feat(release): クロスプラットフォームビルド + リリース workflow (#140)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           }
 
           WIN_SIG_PATH=$(assert_one_sig "*.msi.zip.sig")
-          MAC_SIG_PATH=$(assert_one_sig "*aarch64*.dmg.tar.gz.sig")
+          MAC_SIG_PATH=$(assert_one_sig "*aarch64*.app.tar.gz.sig")
           LIN_SIG_PATH=$(assert_one_sig "*.AppImage.tar.gz.sig")
 
           WIN_BASE=$(basename "$WIN_SIG_PATH" .sig)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,184 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (must already exist, e.g. v0.1.0)'
+        required: true
+        type: string
+
+jobs:
+  # ── 1. Draft release を作成し release_id を後続ジョブに渡す ─────────────────
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
+      tag: ${{ steps.resolve-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: resolve-tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create draft release
+        id: create
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.resolve-tag.outputs.tag }}"
+          gh release create "$TAG" \
+            --draft \
+            --generate-notes \
+            --title "$TAG"
+          RELEASE_ID=$(gh release view "$TAG" --json databaseId --jq .databaseId)
+          echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
+
+  # ── 2. クロスプラットフォームビルド + 成果物アップロード ───────────────────
+  build-tauri:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            tauri-args: ''
+          - platform: macos-latest
+            rust-target: aarch64-apple-darwin
+            tauri-args: '--target aarch64-apple-darwin'
+          - platform: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+            tauri-args: ''
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Linux system dependencies
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            libdbus-1-dev \
+            libssl-dev \
+            librsvg2-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            pkg-config \
+            wget
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo target
+        uses: actions/cache@v5
+        with:
+          path: src-tauri/target
+          key: ${{ runner.os }}-cargo-target-release-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-target-release-
+
+      - name: Build and upload Tauri artifacts
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          args: ${{ matrix.tauri-args }}
+          includeUpdaterJson: false
+
+  # ── 3. 全プラットフォームの署名を集約して latest.json を生成・アップロード ──
+  publish-updater-manifest:
+    needs: [create-release, build-tauri]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download updater signatures
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          mkdir -p sigs
+          gh release download "$TAG" --pattern '*.sig' --dir sigs
+          echo "Downloaded signatures:"
+          ls -la sigs/
+
+      - name: Build latest.json
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          VERSION="${TAG#v}"
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          WIN_SIG=$(cat "sigs/arbor_${VERSION}_x64_en-US.msi.zip.sig")
+          MAC_SIG=$(cat "sigs/arbor_${VERSION}_aarch64.dmg.tar.gz.sig")
+          LIN_SIG=$(cat "sigs/arbor_${VERSION}_amd64.AppImage.tar.gz.sig")
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg pub_date "$PUB_DATE" \
+            --arg win_url "${BASE_URL}/arbor_${VERSION}_x64_en-US.msi.zip" \
+            --arg win_sig "$WIN_SIG" \
+            --arg mac_url "${BASE_URL}/arbor_${VERSION}_aarch64.dmg.tar.gz" \
+            --arg mac_sig "$MAC_SIG" \
+            --arg lin_url "${BASE_URL}/arbor_${VERSION}_amd64.AppImage.tar.gz" \
+            --arg lin_sig "$LIN_SIG" \
+            '{
+              version: $version,
+              notes: "",
+              pub_date: $pub_date,
+              platforms: {
+                "windows-x86_64": { url: $win_url, signature: $win_sig },
+                "darwin-aarch64": { url: $mac_url, signature: $mac_sig },
+                "linux-x86_64":  { url: $lin_url, signature: $lin_sig }
+              }
+            }' > latest.json
+
+          echo "Generated latest.json:"
+          cat latest.json
+
+      - name: Upload latest.json to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ needs.create-release.outputs.tag }}"
+          gh release upload "$TAG" latest.json --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,17 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
-  # ── 1. Draft release を作成し release_id を後続ジョブに渡す ─────────────────
+  # ── 1. Draft release を作成し release_id / tag を後続ジョブに渡す ──────────
   create-release:
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create.outputs.release_id }}
       tag: ${{ steps.resolve-tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
-
       - name: Resolve tag
         id: resolve-tag
         run: |
@@ -30,16 +31,24 @@ jobs:
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create draft release
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.resolve-tag.outputs.tag }}
+
+      - name: Create draft release (idempotent)
         id: create
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.resolve-tag.outputs.tag }}"
-          gh release create "$TAG" \
-            --draft \
-            --generate-notes \
-            --title "$TAG"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists; reusing it"
+          else
+            gh release create "$TAG" \
+              --draft \
+              --generate-notes \
+              --title "$TAG"
+          fi
           RELEASE_ID=$(gh release view "$TAG" --json databaseId --jq .databaseId)
           echo "release_id=$RELEASE_ID" >> $GITHUB_OUTPUT
 
@@ -62,6 +71,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.create-release.outputs.tag }}
 
       - name: Install Linux system dependencies
         if: matrix.platform == 'ubuntu-latest'
@@ -131,6 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.create-release.outputs.tag }}
 
       - name: Download updater signatures
         env:
@@ -149,18 +162,38 @@ jobs:
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}"
           PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          WIN_SIG=$(cat "sigs/arbor_${VERSION}_x64_en-US.msi.zip.sig")
-          MAC_SIG=$(cat "sigs/arbor_${VERSION}_aarch64.dmg.tar.gz.sig")
-          LIN_SIG=$(cat "sigs/arbor_${VERSION}_amd64.AppImage.tar.gz.sig")
+          # glob + 1件アサート。ファイル名の変動に耐えつつ意図しない複数一致を検出する。
+          assert_one_sig() {
+            local pattern="$1"
+            local matched=( sigs/${pattern} )
+            if [[ ${#matched[@]} -ne 1 || ! -f "${matched[0]}" ]]; then
+              echo "ERROR: pattern '${pattern}' matched ${#matched[@]} file(s):"
+              ls sigs/ || true
+              exit 1
+            fi
+            echo "${matched[0]}"
+          }
+
+          WIN_SIG_PATH=$(assert_one_sig "*.msi.zip.sig")
+          MAC_SIG_PATH=$(assert_one_sig "*aarch64*.dmg.tar.gz.sig")
+          LIN_SIG_PATH=$(assert_one_sig "*.AppImage.tar.gz.sig")
+
+          WIN_BASE=$(basename "$WIN_SIG_PATH" .sig)
+          MAC_BASE=$(basename "$MAC_SIG_PATH" .sig)
+          LIN_BASE=$(basename "$LIN_SIG_PATH" .sig)
+
+          WIN_SIG=$(cat "$WIN_SIG_PATH")
+          MAC_SIG=$(cat "$MAC_SIG_PATH")
+          LIN_SIG=$(cat "$LIN_SIG_PATH")
 
           jq -n \
             --arg version "$VERSION" \
             --arg pub_date "$PUB_DATE" \
-            --arg win_url "${BASE_URL}/arbor_${VERSION}_x64_en-US.msi.zip" \
+            --arg win_url "${BASE_URL}/${WIN_BASE}" \
             --arg win_sig "$WIN_SIG" \
-            --arg mac_url "${BASE_URL}/arbor_${VERSION}_aarch64.dmg.tar.gz" \
+            --arg mac_url "${BASE_URL}/${MAC_BASE}" \
             --arg mac_sig "$MAC_SIG" \
-            --arg lin_url "${BASE_URL}/arbor_${VERSION}_amd64.AppImage.tar.gz" \
+            --arg lin_url "${BASE_URL}/${LIN_BASE}" \
             --arg lin_sig "$LIN_SIG" \
             '{
               version: $version,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
   - Job 1: draft release 作成（`gh release create --generate-notes`）
   - Job 2: matrix ビルド（windows-latest / macos-latest / ubuntu-latest）
     - Windows: `.msi` + `.msi.zip` + 署名 (x86_64-pc-windows-msvc)
-    - macOS: `.dmg` + `.dmg.tar.gz` + 署名 (aarch64-apple-darwin)
+    - macOS: `.dmg`（配布）/ `.app.tar.gz` + 署名（updater）(aarch64-apple-darwin)
     - Linux: `.AppImage` + `.deb` + 署名 (x86_64-unknown-linux-gnu)
     - `TAURI_SIGNING_PRIVATE_KEY` / `_PASSWORD` を Secrets から注入
   - Job 3: 全プラットフォームの `.sig` を集約し `latest.json` を生成・アップロード

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ Format: [Conventional Commits](https://www.conventionalcommits.org/). Unreleased
 
 ### feat — Phase 4
 
+- **クロスプラットフォームリリース workflow** (P4-05/06/07) (#140)
+  - `.github/workflows/release.yml` 新規作成（`v*` タグ push / `workflow_dispatch` で発火）
+  - Job 1: draft release 作成（`gh release create --generate-notes`）
+  - Job 2: matrix ビルド（windows-latest / macos-latest / ubuntu-latest）
+    - Windows: `.msi` + `.msi.zip` + 署名 (x86_64-pc-windows-msvc)
+    - macOS: `.dmg` + `.dmg.tar.gz` + 署名 (aarch64-apple-darwin)
+    - Linux: `.AppImage` + `.deb` + 署名 (x86_64-unknown-linux-gnu)
+    - `TAURI_SIGNING_PRIVATE_KEY` / `_PASSWORD` を Secrets から注入
+  - Job 3: 全プラットフォームの `.sig` を集約し `latest.json` を生成・アップロード
+  - `bundle.createUpdaterArtifacts: "v1Compatible"` を `tauri.conf.json` に追加
+
 - **updater 公開鍵を tauri.conf.json に登録** (P4-05) (#139)
   - `src-tauri/tauri.conf.json` の `plugins.updater.pubkey` に minisign 公開鍵を設定
   - 対応する秘密鍵は GitHub Secrets (`TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) に配置済み
-  - release workflow（#140）で `latest.json` 署名生成に使用予定
 
 - **コマンドパレット** (P4-01) (#102)
   - `Ctrl/Cmd+K` でパレットを開閉

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": "v1Compatible",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yml` を新規作成（Issue #140）
- `v*` タグ push または `workflow_dispatch` で発火するリリースパイプライン
- `tauri.conf.json` に `bundle.createUpdaterArtifacts: "v1Compatible"` を追加

## 実装内容

### Job 1: `create-release`
- `gh release create --draft --generate-notes` で draft release を作成（idempotent: 既存 draft は reuse）
- `databaseId` を outputs に渡して後続 Job で使用

### Job 2: `build-tauri` (matrix)
| Platform | Runner | Rust target | 配布 artifact | updater artifact |
|---|---|---|---|---|
| Windows | windows-latest | x86_64-pc-windows-msvc | `.msi` | `.msi.zip` + `.sig` |
| macOS | macos-latest | aarch64-apple-darwin | `.dmg` | `.app.tar.gz` + `.sig` |
| Linux | ubuntu-latest | x86_64-unknown-linux-gnu | `.AppImage` `.deb` | `.AppImage.tar.gz` + `.sig` |

- `tauri-apps/tauri-action@v0` でビルド + release へアップロード
- `TAURI_SIGNING_PRIVATE_KEY` / `_PASSWORD` を GitHub Secrets から注入（#139 完了済み）
- `includeUpdaterJson: false` で個別 `latest.json` 生成を抑制（Job 3 で集約）

### Job 3: `publish-updater-manifest`
- 全 build-tauri 完了後に実行
- `gh release download --pattern '*.sig'` で署名ファイルを取得
- glob + 1件アサートでファイル名変動に対応、URL も取得したファイル名から動的構築
- `jq` で v1Compatible 形式の `latest.json` を組み立て
- `gh release upload --clobber` でアップロード

## 注意事項

- **未署名インストーラー**: Windows SmartScreen / macOS Gatekeeper の警告あり（コードサイニング証明書 / Apple Developer ID は #141/#142 で後追い対応）
- **macOS**: universal binary (Intel + Apple Silicon) は別途検討。現在は `aarch64-apple-darwin` のみ
- **テスト**: `v0.0.1-test` 等のテストタグを push して受け入れ条件を確認予定

## 受け入れ条件

- [ ] テストタグ push で workflow 全 Job が成功する
- [ ] draft release に `.msi` / `.dmg` / `.AppImage` / `.deb` / `latest.json` が揃う
- [ ] `latest.json` に全プラットフォームの URL と signature が含まれる

## 依存

- 先行: #138 (updater プラグイン導入)
- 先行: #139 (署名鍵 Secrets 配置 ✅)
- 親: #105 / #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)