### PR TITLE
fix(ci): codecov-action を v6.0.2(SHA固定)に更新し fail_ci_if_error を true に復元

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,12 @@ jobs:
       - name: Upload Rust coverage to Codecov
         # fork PRs do not have access to secrets; skip upload in that case
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: src-tauri/lcov.info
           flags: rust
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   # ── Frontend ─────────────────────────────────────────────────────────────────
   frontend:
@@ -205,9 +205,9 @@ jobs:
       - name: Upload frontend coverage to Codecov
         # fork PRs do not have access to secrets; skip upload in that case
         if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
           flags: frontend
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
## 概要

codecov の GPG 鍵不具合は **v6.0.2（2026-06-07 リリース）で修正済み**。
SHA 固定で恒久対応に切り替え、`fail_ci_if_error` を `true` に復元する。

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| action 参照 | `codecov/codecov-action@v6` | `codecov/codecov-action@fb8b3582...` (`# v6.0.2`) |
| fail_ci_if_error | `false`（暫定回避） | `true`（本来の設定に復元） |

## SHA 固定の理由

浮動タグ（`@v6`）は再び書き換えられるリスクがある。commit SHA 固定により、検証済みのバイナリのみを実行することを保証する。

## 参考

- [codecov/codecov-action v6.0.2 リリースノート](https://github.com/codecov/codecov-action/releases/tag/v6.0.2)

Generated with [Claude Code](https://claude.com/claude-code)